### PR TITLE
Github Action에서 ``run`` 태그 문법 문제 수정

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Writing application-deploy.yml
-        run:
+        run: |
           touch ./src/main/resources/application-deploy.yml
           echo "${{ secrets.APPLICATION_DEPLOY_YAML }}" > ./src/main/resources/application-prod.yml
       - name: Connect deploy key


### PR DESCRIPTION
## 📋 작업 내용
> ``|`` 을 붙여 2줄의 명령어가 1줄로 인식되던 문제를 수정하였습니다

## 🤝 리뷰 시 참고사항
> 

## ✅ 체크리스트
- [x] 이 작업으로 인해 변경이 필요한 문서를 작성 또는 수정했나요? (e.g. `README`, `.env.example`)
- [ ] 작업한 코드가 정상적으로 동작하는지 확인했나요?
- [ ] 작업한 코드에 대한 테스트 코드를 작성하거나 수정했나요?
- [x] Merge 대상 브랜치를 올바르게 설정했나요?
- [x] 해당 PR과 관련 없는 작업이 포함되지는 않았나요?
- [x] PR의 올바른 라벨과 리뷰어를 설정했나요?