### PR TITLE
증빙자료 관련 persistence Port/Adapter 수정

### DIFF
--- a/src/main/java/team/incude/gsmc/v2/domain/evidence/application/EvidenceApplicationAdapter.java
+++ b/src/main/java/team/incude/gsmc/v2/domain/evidence/application/EvidenceApplicationAdapter.java
@@ -19,8 +19,8 @@ public class EvidenceApplicationAdapter implements EvidenceApplicationPort {
     private final CreateReadingEvidenceUseCase createReadingEvidenceUseCase;
     private final DeleteEvidenceUseCase deleteEvidenceUseCase;
     private final FindEvidenceByCurrentUserAndTypeUseCase findEvidenceByCurrentUserAndTypeUseCase;
-    private final FindEvidenceByFilteringByEmailAndTitleAndTypeUseCase findEvidenceByFilteringByEmailAndTitleAndTypeUseCase;
-    private final FindEvidenceByEmailAndFilteringTypeAndStatusUseCase findEvidenceByEmailAndFilteringTypeAndStatusUseCase;
+    private final FindEvidenceByFilteringByStudentCodeAndTitleAndTypeUseCase findEvidenceByFilteringByStudentCodeAndTitleAndTypeUseCase;
+    private final FindEvidenceByStudentCodeAndFilteringTypeAndStatusUseCase findEvidenceByStudentCodeAndFilteringTypeAndStatusUseCase;
     private final UpdateActivityEvidenceByCurrentUserUseCase updateActivityEvidenceByCurrentUserUseCase;
     private final UpdateOtherEvidenceByCurrentUserUseCase updateOtherEvidenceByCurrentUserUseCase;
     private final UpdateReadingEvidenceByCurrentUserUseCase updateReadingEvidenceByCurrentUserUseCase;
@@ -32,13 +32,13 @@ public class EvidenceApplicationAdapter implements EvidenceApplicationPort {
     }
 
     @Override
-    public GetEvidencesResponse findEvidenceByEmailAndTypeAndStatus(String email, EvidenceType evidenceType, ReviewStatus status) {
-        return findEvidenceByEmailAndFilteringTypeAndStatusUseCase.execute(email, evidenceType, status);
+    public GetEvidencesResponse findEvidenceByStudentCodeAndTypeAndStatus(Integer studentCode, EvidenceType evidenceType, ReviewStatus status) {
+        return findEvidenceByStudentCodeAndFilteringTypeAndStatusUseCase.execute(studentCode, evidenceType, status);
     }
 
     @Override
-    public GetEvidencesResponse findEvidenceByEmailAndTitleAndType(String email, String title, EvidenceType evidenceType) {
-        return findEvidenceByFilteringByEmailAndTitleAndTypeUseCase.execute(email, title, evidenceType);
+    public GetEvidencesResponse findEvidenceByStudentCodeAndTitleAndType(Integer studentCode, String title, EvidenceType evidenceType) {
+        return findEvidenceByFilteringByStudentCodeAndTitleAndTypeUseCase.execute(studentCode, title, evidenceType);
     }
 
     @Override

--- a/src/main/java/team/incude/gsmc/v2/domain/evidence/application/port/ActivityEvidencePersistencePort.java
+++ b/src/main/java/team/incude/gsmc/v2/domain/evidence/application/port/ActivityEvidencePersistencePort.java
@@ -12,7 +12,7 @@ import java.util.List;
 public interface ActivityEvidencePersistencePort {
     List<ActivityEvidence> findActivityEvidenceByEmailAndEvidenceType(String email, EvidenceType evidenceType);
 
-    List<ActivityEvidence> findActivityEvidenceByEmailAndTypeAndTitleAndStatusAndGradeAndClassNumber(String email, EvidenceType evidenceType, String title, ReviewStatus status, Integer grade, Integer classNumber);
+    List<ActivityEvidence> findActivityEvidenceByStudentCodeAndTypeAndTitleAndStatusAndGradeAndClassNumber(Integer studentCode, EvidenceType evidenceType, String title, ReviewStatus status, Integer grade, Integer classNumber);
 
     ActivityEvidence saveActivityEvidence(ActivityEvidence activityEvidence);
 

--- a/src/main/java/team/incude/gsmc/v2/domain/evidence/application/port/EvidenceApplicationPort.java
+++ b/src/main/java/team/incude/gsmc/v2/domain/evidence/application/port/EvidenceApplicationPort.java
@@ -11,9 +11,9 @@ import team.incude.gsmc.v2.global.annotation.port.Port;
 public interface EvidenceApplicationPort {
     GetEvidencesResponse findEvidenceByCurrentUserAndType(EvidenceType evidenceType);
 
-    GetEvidencesResponse findEvidenceByEmailAndTypeAndStatus(String email, EvidenceType evidenceType, ReviewStatus status);
+    GetEvidencesResponse findEvidenceByStudentCodeAndTypeAndStatus(Integer studentCode, EvidenceType evidenceType, ReviewStatus status);
 
-    GetEvidencesResponse findEvidenceByEmailAndTitleAndType(String email, String title, EvidenceType evidenceType);
+    GetEvidencesResponse findEvidenceByStudentCodeAndTitleAndType(Integer studentCode, String title, EvidenceType evidenceType);
 
     void updateMajorEvidenceByCurrentUser(Long evidenceId, String title, String content, MultipartFile file);
 

--- a/src/main/java/team/incude/gsmc/v2/domain/evidence/application/port/OtherEvidencePersistencePort.java
+++ b/src/main/java/team/incude/gsmc/v2/domain/evidence/application/port/OtherEvidencePersistencePort.java
@@ -14,7 +14,7 @@ public interface OtherEvidencePersistencePort {
 
     List<OtherEvidence> findOtherEvidenceByEmail(String email);
 
-    List<OtherEvidence> findOtherEvidenceByEmailAndTypeAndStatusAndGradeAndClassNumber(String email, EvidenceType evidenceType, ReviewStatus status, Integer grade, Integer classNumber);
+    List<OtherEvidence> findOtherEvidenceByStudentCodeAndTypeAndStatusAndGradeAndClassNumber(Integer studentCode, EvidenceType evidenceType, ReviewStatus status, Integer grade, Integer classNumber);
 
     void deleteOtherEvidenceById(Long evidenceId);
 

--- a/src/main/java/team/incude/gsmc/v2/domain/evidence/application/port/ReadingEvidencePersistencePort.java
+++ b/src/main/java/team/incude/gsmc/v2/domain/evidence/application/port/ReadingEvidencePersistencePort.java
@@ -14,7 +14,7 @@ public interface ReadingEvidencePersistencePort {
 
     ReadingEvidence saveReadingEvidence(ReadingEvidence readingEvidence);
 
-    List<ReadingEvidence> findReadingEvidenceByEmailAndTitleAndTypeAndStatusAndGradeAndClassNumber(String email, String title, EvidenceType evidenceType, ReviewStatus status, Integer grade, Integer classNumber);
+    List<ReadingEvidence> findReadingEvidenceByStudentCodeAndTitleAndTypeAndStatusAndGradeAndClassNumber(Integer studentCode, String title, EvidenceType evidenceType, ReviewStatus status, Integer grade, Integer classNumber);
 
     void deleteReadingEvidenceById(Long evidenceId);
 

--- a/src/main/java/team/incude/gsmc/v2/domain/evidence/application/usecase/FindEvidenceByFilteringByStudentCodeAndTitleAndTypeUseCase.java
+++ b/src/main/java/team/incude/gsmc/v2/domain/evidence/application/usecase/FindEvidenceByFilteringByStudentCodeAndTitleAndTypeUseCase.java
@@ -3,6 +3,6 @@ package team.incude.gsmc.v2.domain.evidence.application.usecase;
 import team.incude.gsmc.v2.domain.evidence.domain.constant.EvidenceType;
 import team.incude.gsmc.v2.domain.evidence.presentation.data.response.GetEvidencesResponse;
 
-public interface FindEvidenceByFilteringByEmailAndTitleAndTypeUseCase {
-    GetEvidencesResponse execute(String email, String title, EvidenceType evidenceType);
+public interface FindEvidenceByFilteringByStudentCodeAndTitleAndTypeUseCase {
+    GetEvidencesResponse execute(Integer studentCode, String title, EvidenceType evidenceType);
 }

--- a/src/main/java/team/incude/gsmc/v2/domain/evidence/application/usecase/FindEvidenceByStudentCodeAndFilteringTypeAndStatusUseCase.java
+++ b/src/main/java/team/incude/gsmc/v2/domain/evidence/application/usecase/FindEvidenceByStudentCodeAndFilteringTypeAndStatusUseCase.java
@@ -4,6 +4,6 @@ import team.incude.gsmc.v2.domain.evidence.domain.constant.EvidenceType;
 import team.incude.gsmc.v2.domain.evidence.domain.constant.ReviewStatus;
 import team.incude.gsmc.v2.domain.evidence.presentation.data.response.GetEvidencesResponse;
 
-public interface FindEvidenceByEmailAndFilteringTypeAndStatusUseCase {
-    GetEvidencesResponse execute(String email, EvidenceType type, ReviewStatus status);
+public interface FindEvidenceByStudentCodeAndFilteringTypeAndStatusUseCase {
+    GetEvidencesResponse execute(Integer studentCode, EvidenceType type, ReviewStatus status);
 }

--- a/src/main/java/team/incude/gsmc/v2/domain/evidence/application/usecase/service/CreateActivityEvidenceService.java
+++ b/src/main/java/team/incude/gsmc/v2/domain/evidence/application/usecase/service/CreateActivityEvidenceService.java
@@ -1,0 +1,28 @@
+package team.incude.gsmc.v2.domain.evidence.application.usecase.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import team.incude.gsmc.v2.domain.evidence.application.port.ActivityEvidencePersistencePort;
+import team.incude.gsmc.v2.domain.evidence.application.port.S3Port;
+import team.incude.gsmc.v2.domain.evidence.application.usecase.CreateActivityEvidenceUseCase;
+import team.incude.gsmc.v2.domain.evidence.domain.constant.EvidenceType;
+import team.incude.gsmc.v2.domain.member.domain.Member;
+import team.incude.gsmc.v2.domain.score.application.port.ScorePersistencePort;
+import team.incude.gsmc.v2.global.security.jwt.usecase.service.CurrentMemberProvider;
+
+@Service
+@RequiredArgsConstructor
+public class CreateActivityEvidenceService implements CreateActivityEvidenceUseCase {
+
+    private final ActivityEvidencePersistencePort activityEvidencePersistencePort;
+    private final ScorePersistencePort scorePersistencePort;
+    private final S3Port s3Port;
+    private final CurrentMemberProvider currentMemberProvider;
+
+
+    @Override
+    public void execute(String categoryName, String title, String content, MultipartFile file, EvidenceType activityType) {
+        Member member = currentMemberProvider.getCurrentUser();
+    }
+}

--- a/src/main/java/team/incude/gsmc/v2/domain/evidence/persistence/ActivityEvidencePersistenceAdapter.java
+++ b/src/main/java/team/incude/gsmc/v2/domain/evidence/persistence/ActivityEvidencePersistenceAdapter.java
@@ -49,15 +49,14 @@ public class ActivityEvidencePersistenceAdapter implements ActivityEvidencePersi
     }
 
     @Override
-    public List<ActivityEvidence> findActivityEvidenceByEmailAndTypeAndTitleAndStatusAndGradeAndClassNumber(String email, EvidenceType evidenceType, String title, ReviewStatus status, Integer grade, Integer classNumber) {
+    public List<ActivityEvidence> findActivityEvidenceByStudentCodeAndTypeAndTitleAndStatusAndGradeAndClassNumber(Integer studentCode, EvidenceType evidenceType, String title, ReviewStatus status, Integer grade, Integer classNumber) {
         return jpaQueryFactory
                 .selectFrom(activityEvidenceJpaEntity)
                 .join(activityEvidenceJpaEntity.evidence, evidenceJpaEntity).fetchJoin()
                 .join(evidenceJpaEntity.score, scoreJpaEntity).fetchJoin()
-                .join(scoreJpaEntity.member, memberJpaEntity).fetchJoin()
-                .join(studentDetailJpaEntity).on(studentDetailJpaEntity.member.eq(memberJpaEntity)).fetchJoin()
+                .join(studentDetailJpaEntity).on(studentDetailJpaEntity.studentCode.eq(studentCode)).fetchJoin()
                 .where(
-                        memberEmailEq(email),
+                        studentCodeEq(studentCode),
                         evidenceTypeEq(evidenceType),
                         titleEq(title),
                         statusEq(status),
@@ -101,6 +100,11 @@ public class ActivityEvidencePersistenceAdapter implements ActivityEvidencePersi
     private BooleanExpression memberEmailEq(String email) {
         if (email == null) return null;
         return memberJpaEntity.email.eq(email);
+    }
+
+    private BooleanExpression studentCodeEq(Integer studentCode) {
+        if (studentCode == null) return null;
+        return studentDetailJpaEntity.studentCode.eq(studentCode);
     }
 
     private BooleanExpression evidenceTypeEq(EvidenceType evidenceType) {

--- a/src/main/java/team/incude/gsmc/v2/domain/evidence/persistence/OtherEvidencePersistenceAdapter.java
+++ b/src/main/java/team/incude/gsmc/v2/domain/evidence/persistence/OtherEvidencePersistenceAdapter.java
@@ -35,16 +35,16 @@ public class OtherEvidencePersistenceAdapter implements OtherEvidencePersistence
     }
 
     @Override
-    public List<OtherEvidence> findOtherEvidenceByEmailAndTypeAndStatusAndGradeAndClassNumber(String email, EvidenceType evidenceType, ReviewStatus status, Integer grade, Integer classNumber) {
+    public List<OtherEvidence> findOtherEvidenceByStudentCodeAndTypeAndStatusAndGradeAndClassNumber(Integer studentCode, EvidenceType evidenceType, ReviewStatus status, Integer grade, Integer classNumber) {
         return jpaQueryFactory
                 .selectFrom(otherEvidenceJpaEntity)
                 .join(otherEvidenceJpaEntity.evidence, evidenceJpaEntity).fetchJoin()
                 .join(evidenceJpaEntity.score, scoreJpaEntity).fetchJoin()
-                .join(scoreJpaEntity.member, memberJpaEntity).fetchJoin()
+                .join(studentDetailJpaEntity).on(studentDetailJpaEntity.studentCode.eq(studentCode)).fetchJoin()
+                .join(studentDetailJpaEntity.member, memberJpaEntity).fetchJoin()
                 .join(scoreJpaEntity.category, categoryJpaEntity).fetchJoin()
-                .join(studentDetailJpaEntity).on(studentDetailJpaEntity.member.id.eq(memberJpaEntity.id)).fetchJoin()
                 .where(
-                        memberEmailEq(email),
+                        studentCodeEq(studentCode),
                         evidenceTypeEq(evidenceType),
                         statusEq(status),
                         gradeEq(grade),
@@ -87,6 +87,12 @@ public class OtherEvidencePersistenceAdapter implements OtherEvidencePersistence
         if (email == null) return null;
         return memberJpaEntity.email.eq(email);
     }
+
+    private BooleanExpression studentCodeEq(Integer studentCode) {
+        if (studentCode == null) return null;
+        return studentDetailJpaEntity.studentCode.eq(studentCode);
+    }
+
     private BooleanExpression evidenceTypeEq(EvidenceType evidenceType) {
         if (evidenceType == null) return null;
         return evidenceJpaEntity.evidenceType.eq(evidenceType);

--- a/src/main/java/team/incude/gsmc/v2/domain/evidence/persistence/ReadingEvidencePersistenceAdapter.java
+++ b/src/main/java/team/incude/gsmc/v2/domain/evidence/persistence/ReadingEvidencePersistenceAdapter.java
@@ -50,15 +50,15 @@ public class ReadingEvidencePersistenceAdapter implements ReadingEvidencePersist
     }
 
     @Override
-    public List<ReadingEvidence> findReadingEvidenceByEmailAndTitleAndTypeAndStatusAndGradeAndClassNumber(String email, String title, EvidenceType evidenceType, ReviewStatus status, Integer grade, Integer classNumber) {
+    public List<ReadingEvidence> findReadingEvidenceByStudentCodeAndTitleAndTypeAndStatusAndGradeAndClassNumber(Integer studentCode, String title, EvidenceType evidenceType, ReviewStatus status, Integer grade, Integer classNumber) {
         return jpaQueryFactory
                 .selectFrom(readingEvidenceJpaEntity)
                 .join(readingEvidenceJpaEntity.evidence, evidenceJpaEntity).fetchJoin()
                 .join(evidenceJpaEntity.score, scoreJpaEntity).fetchJoin()
-                .join(scoreJpaEntity.member, memberJpaEntity).fetchJoin()
-                .join(studentDetailJpaEntity).on(studentDetailJpaEntity.member.id.eq(memberJpaEntity.id)).fetchJoin()
+                .join(studentDetailJpaEntity).on(studentDetailJpaEntity.studentCode.eq(studentCode))
+                .join(studentDetailJpaEntity.member, memberJpaEntity).fetchJoin()
                 .where(
-                        memberEmailEq(email),
+                        studentCodeEq(studentCode),
                         titleEq(title),
                         evidenceTypeEq(evidenceType),
                         statusEq(status),
@@ -92,6 +92,11 @@ public class ReadingEvidencePersistenceAdapter implements ReadingEvidencePersist
     private BooleanExpression memberEmailEq(String email) {
         if (email == null) return null;
         return memberJpaEntity.email.eq(email);
+    }
+
+    private BooleanExpression studentCodeEq(Integer studentCode) {
+        if (studentCode == null) return null;
+        return studentDetailJpaEntity.studentCode.eq(studentCode);
     }
 
     private BooleanExpression titleEq(String title) {


### PR DESCRIPTION
## 📋 작업 내용
> 증빙자료 관련 persistence Port/Adapter의 일부 메서드의 파라미터를 email에서 studentCode로 수정했습니다

## 🤝 리뷰 시 참고사항
> 일부 메서드들 중 파라미터가 email인 메서드가 있는데 이 같은 경우에는 `currentMemberProvider`를 이용해 가져온 `member`의 emali 필드를 사용하여 조회하기 위해 수정하지 않았습니다

## ✅ 체크리스트
> 추가적으로 필요한 체크리스트가 있다면 추가적으로 작성해주세요.
- [x] 이 작업으로 인해 변경이 필요한 문서를 작성 또는 수정했나요? (e.g. `README`, `.env.example`)
- [ ] 작업한 코드가 정상적으로 동작하는지 확인했나요?
- [ ] 작업한 코드에 대한 테스트 코드를 작성하거나 수정했나요?
- [x] Merge 대상 브랜치를 올바르게 설정했나요?
- [x] 해당 PR과 관련 없는 작업이 포함되지는 않았나요?
- [x] PR의 올바른 라벨과 리뷰어를 설정했나요?