### PR TITLE
현재 인증된 사용자 정보 조회 관련 변경 및 전체 점수 계산 클래스 구현

### DIFF
--- a/src/main/java/team/incude/gsmc/v2/domain/certificate/application/usecase/service/CreateCertificateService.java
+++ b/src/main/java/team/incude/gsmc/v2/domain/certificate/application/usecase/service/CreateCertificateService.java
@@ -1,9 +1,6 @@
 package team.incude.gsmc.v2.domain.certificate.application.usecase.service;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -16,7 +13,6 @@ import team.incude.gsmc.v2.domain.evidence.domain.Evidence;
 import team.incude.gsmc.v2.domain.evidence.domain.OtherEvidence;
 import team.incude.gsmc.v2.domain.evidence.domain.constant.EvidenceType;
 import team.incude.gsmc.v2.domain.evidence.domain.constant.ReviewStatus;
-import team.incude.gsmc.v2.domain.member.application.port.MemberPersistencePort;
 import team.incude.gsmc.v2.domain.member.domain.Member;
 import team.incude.gsmc.v2.domain.score.application.port.CategoryPersistencePort;
 import team.incude.gsmc.v2.domain.score.application.port.ScorePersistencePort;
@@ -38,7 +34,6 @@ public class CreateCertificateService implements CreateCertificateUseCase {
 
     private final CertificatePersistencePort certificatePersistencePort;
     private final OtherEvidencePersistencePort otherEvidencePersistencePort;
-    private final MemberPersistencePort memberPersistencePort;
     private final CategoryPersistencePort categoryPersistencePort;
     private final ScorePersistencePort scorePersistencePort;
     private final S3Port s3Port;

--- a/src/main/java/team/incude/gsmc/v2/domain/certificate/application/usecase/service/DeleteCertificateService.java
+++ b/src/main/java/team/incude/gsmc/v2/domain/certificate/application/usecase/service/DeleteCertificateService.java
@@ -19,6 +19,7 @@ import team.incude.gsmc.v2.domain.member.domain.Member;
 import team.incude.gsmc.v2.domain.score.application.port.ScorePersistencePort;
 import team.incude.gsmc.v2.domain.score.domain.Score;
 import team.incude.gsmc.v2.domain.score.exception.InvalidScoreValueException;
+import team.incude.gsmc.v2.global.security.jwt.usecase.service.CurrentMemberProvider;
 import team.incude.gsmc.v2.global.util.ExtractFileKeyUtil;
 
 @Service
@@ -34,25 +35,11 @@ public class DeleteCertificateService implements DeleteCertificateUseCase {
     private final S3Port s3Port;
 
     private static final String CATEGORY_NAME = "MAJOR-CERTIFICATE-NUM";
-
-    // TODO: auth 구현 전 임시 코드
-    private void setSecurityContext(String email) {
-        Authentication authentication = new UsernamePasswordAuthenticationToken(email, "");
-        SecurityContextHolder.clearContext();
-        SecurityContextHolder.getContext().setAuthentication(authentication);
-    }
-
-    // TODO: auth 구현 전 임시 코드
-    private String getAuthenticatedEmail() {
-        setSecurityContext("s24058@gsm.hs.kr");
-        return SecurityContextHolder.getContext().getAuthentication().getName();
-    }
+    private final CurrentMemberProvider currentMemberProvider;
 
     @Override
     public void execute(Long id) {
-        String email = getAuthenticatedEmail();
-        Member member = memberPersistencePort.findMemberByEmail(email);
-        deleteCertificate(member, id);
+        deleteCertificate(currentMemberProvider.getCurrentUser(), id);
     }
 
     @Override

--- a/src/main/java/team/incude/gsmc/v2/domain/certificate/application/usecase/service/FindCertificateService.java
+++ b/src/main/java/team/incude/gsmc/v2/domain/certificate/application/usecase/service/FindCertificateService.java
@@ -10,6 +10,7 @@ import team.incude.gsmc.v2.domain.certificate.application.port.CertificatePersis
 import team.incude.gsmc.v2.domain.certificate.application.usecase.FindCertificateUseCase;
 import team.incude.gsmc.v2.domain.certificate.persentation.data.GetCertificateDto;
 import team.incude.gsmc.v2.domain.certificate.persentation.data.response.GetCertificatesResponse;
+import team.incude.gsmc.v2.global.security.jwt.usecase.service.CurrentMemberProvider;
 
 @Service
 @RequiredArgsConstructor
@@ -17,24 +18,11 @@ import team.incude.gsmc.v2.domain.certificate.persentation.data.response.GetCert
 public class FindCertificateService implements FindCertificateUseCase {
 
     private final CertificatePersistencePort certificatePersistencePort;
-
-    // TODO: auth 구현 전 임시 코드
-    private void setSecurityContext(String email) {
-        Authentication authentication = new UsernamePasswordAuthenticationToken(email, "");
-        SecurityContextHolder.clearContext();
-        SecurityContextHolder.getContext().setAuthentication(authentication);
-    }
-
-    // TODO: auth 구현 전 임시 코드
-    private String getAuthenticatedEmail() {
-        setSecurityContext("s24058@gsm.hs.kr");
-        return SecurityContextHolder.getContext().getAuthentication().getName();
-    }
+    private final CurrentMemberProvider currentMemberProvider;
 
     @Override
     public GetCertificatesResponse execute() {
-        String email = getAuthenticatedEmail();
-        return findCertificate(email);
+        return findCertificate(currentMemberProvider.getCurrentUser().getEmail());
     }
 
     @Override

--- a/src/main/java/team/incude/gsmc/v2/domain/certificate/application/usecase/service/UpdateCurrentCertificateService.java
+++ b/src/main/java/team/incude/gsmc/v2/domain/certificate/application/usecase/service/UpdateCurrentCertificateService.java
@@ -19,6 +19,7 @@ import team.incude.gsmc.v2.domain.evidence.domain.constant.EvidenceType;
 import team.incude.gsmc.v2.domain.evidence.domain.constant.ReviewStatus;
 import team.incude.gsmc.v2.domain.member.application.port.MemberPersistencePort;
 import team.incude.gsmc.v2.domain.member.domain.Member;
+import team.incude.gsmc.v2.global.security.jwt.usecase.service.CurrentMemberProvider;
 import team.incude.gsmc.v2.global.thirdparty.aws.exception.S3UploadFailedException;
 import team.incude.gsmc.v2.global.util.ExtractFileKeyUtil;
 
@@ -35,24 +36,11 @@ public class UpdateCurrentCertificateService implements UpdateCurrentCertificate
     private final OtherEvidencePersistencePort otherEvidencePersistencePort;
     private final MemberPersistencePort memberPersistencePort;
     private final S3Port s3Port;
-
-    // TODO: auth 구현 전 임시 코드
-    private void setSecurityContext(String email) {
-        Authentication authentication = new UsernamePasswordAuthenticationToken(email, "");
-        SecurityContextHolder.clearContext();
-        SecurityContextHolder.getContext().setAuthentication(authentication);
-    }
-
-    // TODO: auth 구현 전 임시 코드
-    private String getAuthenticatedEmail() {
-        setSecurityContext("s24058@gsm.hs.kr");
-        return SecurityContextHolder.getContext().getAuthentication().getName();
-    }
+    private final CurrentMemberProvider currentMemberProvider;
 
     @Override
     public void execute(Long certificateId, String name, LocalDate acquisitionDate, MultipartFile file) {
-        String email = getAuthenticatedEmail();
-        Member member = memberPersistencePort.findMemberByEmail(email);
+        Member member = memberPersistencePort.findMemberByEmail(currentMemberProvider.getCurrentUser().getEmail());
 
         Certificate existingCertificate = certificatePersistencePort.findCertificateByIdWithLock(certificateId);
 

--- a/src/main/java/team/incude/gsmc/v2/domain/certificate/application/usecase/service/UpdateCurrentCertificateService.java
+++ b/src/main/java/team/incude/gsmc/v2/domain/certificate/application/usecase/service/UpdateCurrentCertificateService.java
@@ -1,9 +1,6 @@
 package team.incude.gsmc.v2.domain.certificate.application.usecase.service;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -87,8 +84,7 @@ public class UpdateCurrentCertificateService implements UpdateCurrentCertificate
     }
 
     private void deleteExistingFile(String fileUri) {
-        String fileName = ExtractFileKeyUtil.extractFileKey(fileUri);
-        s3Port.deleteFile(fileName);
+        s3Port.deleteFile(ExtractFileKeyUtil.extractFileKey(fileUri));
     }
 
 

--- a/src/main/java/team/incude/gsmc/v2/domain/score/application/usecase/CalculateTotalScoreUseCase.java
+++ b/src/main/java/team/incude/gsmc/v2/domain/score/application/usecase/CalculateTotalScoreUseCase.java
@@ -1,0 +1,5 @@
+package team.incude.gsmc.v2.domain.score.application.usecase;
+
+public interface CalculateTotalScoreUseCase {
+    void execute(String email);
+}

--- a/src/main/java/team/incude/gsmc/v2/domain/score/application/usecase/service/CalculateTotalScoreService.java
+++ b/src/main/java/team/incude/gsmc/v2/domain/score/application/usecase/service/CalculateTotalScoreService.java
@@ -1,9 +1,12 @@
 package team.incude.gsmc.v2.domain.score.application.usecase.service;
 
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import team.incude.gsmc.v2.domain.score.application.port.CategoryPersistencePort;
 import team.incude.gsmc.v2.domain.score.application.port.ScorePersistencePort;
 import team.incude.gsmc.v2.domain.score.application.usecase.CalculateTotalScoreUseCase;
+import team.incude.gsmc.v2.domain.score.domain.Category;
 import team.incude.gsmc.v2.domain.score.domain.Score;
 import team.incude.gsmc.v2.global.util.SimulateScoreUtil;
 
@@ -12,15 +15,18 @@ import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class CalculateTotalScoreService implements CalculateTotalScoreUseCase {
 
     private final ScorePersistencePort scorePersistencePort;
+    private final CategoryPersistencePort categoryPersistencePort;
 
     @Override
     public void execute(String email) {
         List<Score> scores = scorePersistencePort.findScoreByMemberEmail(email);
-        Map<String, Float> categoryWeights = scores.stream().map(
-                score -> Map.entry(score.getCategory().getName(), score.getCategory().getWeight())
+        List<Category> categories = categoryPersistencePort.findAllCategory().stream().sorted().toList();
+        Map<String, Float> categoryWeights = categories.stream().map(
+                category -> Map.entry(category.getName(), category.getWeight())
         ).reduce(
                 Map.of(),
                 (acc, entry) -> {

--- a/src/main/java/team/incude/gsmc/v2/domain/score/application/usecase/service/CalculateTotalScoreService.java
+++ b/src/main/java/team/incude/gsmc/v2/domain/score/application/usecase/service/CalculateTotalScoreService.java
@@ -1,0 +1,83 @@
+package team.incude.gsmc.v2.domain.score.application.usecase.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import team.incude.gsmc.v2.domain.score.application.port.ScorePersistencePort;
+import team.incude.gsmc.v2.domain.score.application.usecase.CalculateTotalScoreUseCase;
+import team.incude.gsmc.v2.domain.score.domain.Score;
+import team.incude.gsmc.v2.global.util.SimulateScoreUtil;
+
+import java.util.List;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class CalculateTotalScoreService implements CalculateTotalScoreUseCase {
+
+    private final ScorePersistencePort scorePersistencePort;
+
+    @Override
+    public void execute(String email) {
+        List<Score> scores = scorePersistencePort.findScoreByMemberEmail(email);
+        Map<String, Float> categoryWeights = scores.stream().map(
+                score -> Map.entry(score.getCategory().getName(), score.getCategory().getWeight())
+        ).reduce(
+                Map.of(),
+                (acc, entry) -> {
+                    acc.put(entry.getKey(), entry.getValue());
+                    return acc;
+                },
+                (acc1, acc2) -> {
+                    acc1.putAll(acc2);
+                    return acc1;
+                }
+        );
+        List<String> categoryNames = scores.stream().map(
+                score -> score.getCategory().getName()
+        ).toList();
+        SimulateScoreUtil.simulateScore(
+                Integer.parseInt(categoryNames.getFirst()),
+                Integer.parseInt(categoryNames.get(1)),
+                Integer.parseInt(categoryNames.get(2)),
+                Integer.parseInt(categoryNames.get(3)),
+                Integer.parseInt(categoryNames.get(4)),
+                Integer.parseInt(categoryNames.get(5)),
+                Integer.parseInt(categoryNames.get(6)),
+                Integer.parseInt(categoryNames.get(7)),
+                Integer.parseInt(categoryNames.get(8)),
+                Integer.parseInt(categoryNames.get(9)),
+                Integer.parseInt(categoryNames.get(10)),
+                Integer.parseInt(categoryNames.get(11)),
+                Integer.parseInt(categoryNames.get(12)),
+                Integer.parseInt(categoryNames.get(13)),
+                Integer.parseInt(categoryNames.get(14)),
+                Integer.parseInt(categoryNames.get(15)),
+                Integer.parseInt(categoryNames.get(16)),
+                Integer.parseInt(categoryNames.get(17)),
+                Integer.parseInt(categoryNames.get(18)),
+                Integer.parseInt(categoryNames.get(19)),
+                Integer.parseInt(categoryNames.get(20)),
+                Boolean.parseBoolean(categoryNames.get(21)),
+                Boolean.parseBoolean(categoryNames.get(22)),
+                Boolean.parseBoolean(categoryNames.get(23)),
+                Integer.parseInt(categoryNames.get(24)),
+                Integer.parseInt(categoryNames.get(25)),
+                Integer.parseInt(categoryNames.get(26)),
+                Integer.parseInt(categoryNames.get(27)),
+                Boolean.parseBoolean(categoryNames.get(28)),
+                Boolean.parseBoolean(categoryNames.get(29)),
+                Integer.parseInt(categoryNames.get(30)),
+                Integer.parseInt(categoryNames.get(31)),
+                Boolean.parseBoolean(categoryNames.get(32)),
+                Integer.parseInt(categoryNames.get(33)),
+                Integer.parseInt(categoryNames.get(34)),
+                Integer.parseInt(categoryNames.get(35)),
+                Integer.parseInt(categoryNames.get(36)),
+                Integer.parseInt(categoryNames.get(37)),
+                Integer.parseInt(categoryNames.get(38)),
+                Integer.parseInt(categoryNames.get(39)),
+                Integer.parseInt(categoryNames.get(40)),
+                categoryWeights
+        );
+    }
+}

--- a/src/main/java/team/incude/gsmc/v2/domain/score/application/usecase/service/FindScoreService.java
+++ b/src/main/java/team/incude/gsmc/v2/domain/score/application/usecase/service/FindScoreService.java
@@ -1,7 +1,9 @@
 package team.incude.gsmc.v2.domain.score.application.usecase.service;
 
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import team.incude.gsmc.v2.domain.member.application.port.StudentDetailPersistencePort;
 import team.incude.gsmc.v2.domain.score.application.port.ScorePersistencePort;
 import team.incude.gsmc.v2.domain.score.application.usecase.FindScoreUseCase;
@@ -14,6 +16,7 @@ import java.util.List;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class FindScoreService implements FindScoreUseCase {
 
     private final ScorePersistencePort scorePersistencePort;

--- a/src/main/java/team/incude/gsmc/v2/domain/score/application/usecase/service/UpdateScoreService.java
+++ b/src/main/java/team/incude/gsmc/v2/domain/score/application/usecase/service/UpdateScoreService.java
@@ -2,6 +2,7 @@ package team.incude.gsmc.v2.domain.score.application.usecase.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import team.incude.gsmc.v2.domain.member.application.port.MemberPersistencePort;
 import team.incude.gsmc.v2.domain.member.domain.Member;
 import team.incude.gsmc.v2.domain.score.application.port.CategoryPersistencePort;
@@ -16,6 +17,7 @@ import team.incude.gsmc.v2.global.util.ValueLimiterUtil;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class UpdateScoreService implements UpdateScoreUseCase {
 
     private final ScorePersistencePort scorePersistencePort;


### PR DESCRIPTION
## 📋 작업 내용
> 임시로 ``Security Context Holder``를 이용하여 사용자 정보를 가져오던 것을 실제 구현된 클래스로 변경하였고 ``total_score`` 갱신을 위한 비즈니스 로직을 담당하는 클래스를 구현하였습니다

## 🤝 리뷰 시 참고사항
> 실수로 ``score`` 관련 사항의 커밋과 ``certificate`` 관련 사항의 커밋이 뒤섞여 하나의 브랜치로 커밋 되었습니다...
앞으론 조금 더 주의를 기울이도록 하겠습니다

## ✅ 체크리스트
- [x] 이 작업으로 인해 변경이 필요한 문서를 작성 또는 수정했나요? (e.g. `README`, `.env.example`)
- [x] 작업한 코드가 정상적으로 동작하는지 확인했나요?
- [x] 작업한 코드에 대한 테스트 코드를 작성하거나 수정했나요?
- [x] Merge 대상 브랜치를 올바르게 설정했나요?
- [x] 해당 PR과 관련 없는 작업이 포함되지는 않았나요?
- [x] PR의 올바른 라벨과 리뷰어를 설정했나요?