### PR TITLE
자격증 생성/삭제 로직 누락 문제 수정 및 코드 컨벤션 변경사항 반영

### DIFF
--- a/src/main/java/team/incude/gsmc/v2/domain/certificate/application/CertificateApplicationAdapter.java
+++ b/src/main/java/team/incude/gsmc/v2/domain/certificate/application/CertificateApplicationAdapter.java
@@ -4,7 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.web.multipart.MultipartFile;
 import team.incude.gsmc.v2.domain.certificate.application.port.CertificateApplicationPort;
 import team.incude.gsmc.v2.domain.certificate.application.usecase.*;
-import team.incude.gsmc.v2.domain.certificate.persentation.data.response.GetCertificatesResponse;
+import team.incude.gsmc.v2.domain.certificate.persentation.data.response.GetCertificateResponse;
 import team.incude.gsmc.v2.global.annotation.PortDirection;
 import team.incude.gsmc.v2.global.annotation.adapter.Adapter;
 
@@ -20,12 +20,12 @@ public class CertificateApplicationAdapter implements CertificateApplicationPort
     private final DeleteCertificateUseCase deleteCertificateUseCase;
 
     @Override
-    public GetCertificatesResponse findCurrentCertificate() {
+    public GetCertificateResponse findCurrentCertificate() {
         return findCertificateUseCase.execute();
     }
 
     @Override
-    public GetCertificatesResponse findCertificateByStudentCode(String email) {
+    public GetCertificateResponse findCertificateByStudentCode(String email) {
         return findCertificateUseCase.execute(email);
     }
 

--- a/src/main/java/team/incude/gsmc/v2/domain/certificate/application/port/CertificateApplicationPort.java
+++ b/src/main/java/team/incude/gsmc/v2/domain/certificate/application/port/CertificateApplicationPort.java
@@ -1,7 +1,7 @@
 package team.incude.gsmc.v2.domain.certificate.application.port;
 
 import org.springframework.web.multipart.MultipartFile;
-import team.incude.gsmc.v2.domain.certificate.persentation.data.response.GetCertificatesResponse;
+import team.incude.gsmc.v2.domain.certificate.persentation.data.response.GetCertificateResponse;
 import team.incude.gsmc.v2.global.annotation.PortDirection;
 import team.incude.gsmc.v2.global.annotation.port.Port;
 
@@ -9,9 +9,9 @@ import java.time.LocalDate;
 
 @Port(direction = PortDirection.INBOUND)
 public interface CertificateApplicationPort {
-    GetCertificatesResponse findCurrentCertificate();
+    GetCertificateResponse findCurrentCertificate();
 
-    GetCertificatesResponse findCertificateByStudentCode(String studentCode);
+    GetCertificateResponse findCertificateByStudentCode(String studentCode);
 
     void createCertificate(String name, LocalDate acquisitionDate, MultipartFile file);
 

--- a/src/main/java/team/incude/gsmc/v2/domain/certificate/application/usecase/FindCertificateUseCase.java
+++ b/src/main/java/team/incude/gsmc/v2/domain/certificate/application/usecase/FindCertificateUseCase.java
@@ -1,9 +1,9 @@
 package team.incude.gsmc.v2.domain.certificate.application.usecase;
 
-import team.incude.gsmc.v2.domain.certificate.persentation.data.response.GetCertificatesResponse;
+import team.incude.gsmc.v2.domain.certificate.persentation.data.response.GetCertificateResponse;
 
 public interface FindCertificateUseCase {
-    GetCertificatesResponse execute();
+    GetCertificateResponse execute();
 
-    GetCertificatesResponse execute(String studentCode);
+    GetCertificateResponse execute(String studentCode);
 }

--- a/src/main/java/team/incude/gsmc/v2/domain/certificate/application/usecase/service/CreateCertificateService.java
+++ b/src/main/java/team/incude/gsmc/v2/domain/certificate/application/usecase/service/CreateCertificateService.java
@@ -38,9 +38,9 @@ public class CreateCertificateService implements CreateCertificateUseCase {
     private final ScorePersistencePort scorePersistencePort;
     private final S3Port s3Port;
 
-    private static final String MAJOR_CERTIFICATE_CATEGORY_NAME = "MAJOR-CERTIFICATE-NUM";
-    private static final String HUMANITIES_CERTIFICATE_KOREAN_HISTORY_CATEGORY_NAME = "HUMANITIES-CERTIFICATE-KOREAN-HISTORY";
-    private static final String HUMANITIES_CERTIFICATE_CHINESE_CHARACTER_CATEGORY_NAME = "HUMANITIES-CERTIFICATE-CHINESE-CHARACTER";
+    private static final String MAJOR_CERTIFICATE_CATEGORY_NAME = "MAJOR-CERTIFICATE_NUM";
+    private static final String HUMANITIES_CERTIFICATE_KOREAN_HISTORY_CATEGORY_NAME = "HUMANITIES-CERTIFICATE-KOREAN_HISTORY";
+    private static final String HUMANITIES_CERTIFICATE_CHINESE_CHARACTER_CATEGORY_NAME = "HUMANITIES-CERTIFICATE-CHINESE_CHARACTER";
     private final CurrentMemberProvider currentMemberProvider;
 
     @Override

--- a/src/main/java/team/incude/gsmc/v2/domain/certificate/application/usecase/service/FindCertificateService.java
+++ b/src/main/java/team/incude/gsmc/v2/domain/certificate/application/usecase/service/FindCertificateService.java
@@ -6,7 +6,7 @@ import org.springframework.transaction.annotation.Transactional;
 import team.incude.gsmc.v2.domain.certificate.application.port.CertificatePersistencePort;
 import team.incude.gsmc.v2.domain.certificate.application.usecase.FindCertificateUseCase;
 import team.incude.gsmc.v2.domain.certificate.persentation.data.GetCertificateDto;
-import team.incude.gsmc.v2.domain.certificate.persentation.data.response.GetCertificatesResponse;
+import team.incude.gsmc.v2.domain.certificate.persentation.data.response.GetCertificateResponse;
 import team.incude.gsmc.v2.domain.member.application.port.StudentDetailPersistencePort;
 import team.incude.gsmc.v2.global.security.jwt.usecase.service.CurrentMemberProvider;
 
@@ -20,17 +20,17 @@ public class FindCertificateService implements FindCertificateUseCase {
     private final CurrentMemberProvider currentMemberProvider;
 
     @Override
-    public GetCertificatesResponse execute() {
+    public GetCertificateResponse execute() {
         return findCertificate(studentDetailPersistencePort.findStudentDetailByMemberEmail(currentMemberProvider.getCurrentUser().getEmail()).getStudentCode());
     }
 
     @Override
-    public GetCertificatesResponse execute(String studentCode) {
+    public GetCertificateResponse execute(String studentCode) {
         return findCertificate(studentCode);
     }
 
-    private GetCertificatesResponse findCertificate(String studentCode) {
-        return new GetCertificatesResponse(certificatePersistencePort.findCertificateByStudentDetailStudentCode(studentCode)
+    private GetCertificateResponse findCertificate(String studentCode) {
+        return new GetCertificateResponse(certificatePersistencePort.findCertificateByStudentDetailStudentCode(studentCode)
                 .stream()
                 .map(certificate -> new GetCertificateDto(
                         certificate.getId(),

--- a/src/main/java/team/incude/gsmc/v2/domain/certificate/persentation/CertificateWebAdapter.java
+++ b/src/main/java/team/incude/gsmc/v2/domain/certificate/persentation/CertificateWebAdapter.java
@@ -5,8 +5,10 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
+import team.incude.gsmc.v2.domain.certificate.persentation.data.request.CreateCertificateRequest;
 import team.incude.gsmc.v2.domain.certificate.application.port.CertificateApplicationPort;
-import team.incude.gsmc.v2.domain.certificate.persentation.data.response.GetCertificatesResponse;
+import team.incude.gsmc.v2.domain.certificate.persentation.data.request.PatchCertificateRequest;
+import team.incude.gsmc.v2.domain.certificate.persentation.data.response.GetCertificateResponse;
 
 import java.time.LocalDate;
 
@@ -18,33 +20,27 @@ public class CertificateWebAdapter {
     private final CertificateApplicationPort certificateApplicationPort;
 
     @GetMapping("/current")
-    public ResponseEntity<GetCertificatesResponse> getCurrentCertificates() {
+    public ResponseEntity<GetCertificateResponse> getCurrentCertificates() {
         return ResponseEntity.status(HttpStatus.OK).body(certificateApplicationPort.findCurrentCertificate());
     }
 
     @GetMapping("/{studentCode}")
-    public ResponseEntity<GetCertificatesResponse> getCertificates(@PathVariable(value = "studentCode") String studentCode) {
+    public ResponseEntity<GetCertificateResponse> getCertificates(@PathVariable(value = "studentCode") String studentCode) {
         return ResponseEntity.status(HttpStatus.OK).body(certificateApplicationPort.findCertificateByStudentCode(studentCode));
     }
 
     @PostMapping
-    public ResponseEntity<Void> createCertificates(
-            @RequestParam("name") String name,
-            @RequestParam("acquisitionDate") LocalDate acquisitionDate,
-            @RequestParam("file") MultipartFile file
-    ) {
-        certificateApplicationPort.createCertificate(name, acquisitionDate, file);
+    public ResponseEntity<Void> createCertificates(@ModelAttribute CreateCertificateRequest request) {
+        certificateApplicationPort.createCertificate(request.name(), request.acquisitionDate(), request.file());
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
     @PatchMapping("/current/{certificateId}")
     public ResponseEntity<Void> updateCurrentCertificates(
             @PathVariable(value = "certificateId") Long certificateId,
-            @RequestParam(value = "name", required = false) String name,
-            @RequestParam(value = "acquisitionDate", required = false) LocalDate acquisitionDate,
-            @RequestParam(value = "file", required = false) MultipartFile file
+            @ModelAttribute PatchCertificateRequest request
     ) {
-        certificateApplicationPort.updateCurrentCertificate(certificateId, name, acquisitionDate, file);
+        certificateApplicationPort.updateCurrentCertificate(certificateId, request.name(), request.acquisitionDate(), request.file());
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 
@@ -52,7 +48,7 @@ public class CertificateWebAdapter {
     public ResponseEntity<Void> deleteCertificates(
             @PathVariable(value = "studentCode") String studentCode,
             @PathVariable(value = "certificateId") Long certificateId
-    ){
+    ) {
         certificateApplicationPort.deleteCertificateByStudentCodeAndId(studentCode, certificateId);
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }

--- a/src/main/java/team/incude/gsmc/v2/domain/certificate/persentation/data/request/CreateCertificateRequest.java
+++ b/src/main/java/team/incude/gsmc/v2/domain/certificate/persentation/data/request/CreateCertificateRequest.java
@@ -1,0 +1,13 @@
+package team.incude.gsmc.v2.domain.certificate.persentation.data.request;
+
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.annotations.NotNull;
+
+import java.time.LocalDate;
+
+public record CreateCertificateRequest(
+        @NotNull String name,
+        @NotNull LocalDate acquisitionDate,
+        @NotNull MultipartFile file
+) {
+}

--- a/src/main/java/team/incude/gsmc/v2/domain/certificate/persentation/data/request/PatchCertificateRequest.java
+++ b/src/main/java/team/incude/gsmc/v2/domain/certificate/persentation/data/request/PatchCertificateRequest.java
@@ -1,0 +1,12 @@
+package team.incude.gsmc.v2.domain.certificate.persentation.data.request;
+
+import org.springframework.web.multipart.MultipartFile;
+
+import java.time.LocalDate;
+
+public record PatchCertificateRequest(
+        String name,
+        LocalDate acquisitionDate,
+        MultipartFile file
+) {
+}

--- a/src/main/java/team/incude/gsmc/v2/domain/certificate/persentation/data/response/GetCertificateResponse.java
+++ b/src/main/java/team/incude/gsmc/v2/domain/certificate/persentation/data/response/GetCertificateResponse.java
@@ -4,7 +4,7 @@ import team.incude.gsmc.v2.domain.certificate.persentation.data.GetCertificateDt
 
 import java.util.List;
 
-public record GetCertificatesResponse(
+public record GetCertificateResponse(
         List<GetCertificateDto> certificates
 ) {
 }

--- a/src/test/java/team/incude/gsmc/v2/domain/certificate/application/usecase/service/FindCertificateServiceTest.java
+++ b/src/test/java/team/incude/gsmc/v2/domain/certificate/application/usecase/service/FindCertificateServiceTest.java
@@ -9,7 +9,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import team.incude.gsmc.v2.domain.certificate.application.port.CertificatePersistencePort;
 import team.incude.gsmc.v2.domain.certificate.domain.Certificate;
-import team.incude.gsmc.v2.domain.certificate.persentation.data.response.GetCertificatesResponse;
+import team.incude.gsmc.v2.domain.certificate.persentation.data.response.GetCertificateResponse;
 import team.incude.gsmc.v2.domain.evidence.domain.OtherEvidence;
 import team.incude.gsmc.v2.domain.member.application.port.StudentDetailPersistencePort;
 import team.incude.gsmc.v2.domain.member.domain.Member;
@@ -64,7 +64,7 @@ class FindCertificateServiceTest {
             when(certificatePersistencePort.findCertificateByStudentDetailStudentCode(studentCode)).thenReturn(List.of(certificate));
 
             // when
-            GetCertificatesResponse response = findCertificateService.execute();
+            GetCertificateResponse response = findCertificateService.execute();
 
             // then
             assertThat(response.certificates()).hasSize(1);
@@ -92,7 +92,7 @@ class FindCertificateServiceTest {
                     .thenReturn(List.of(certificate));
 
             // when
-            GetCertificatesResponse response = findCertificateService.execute(studentCode);
+            GetCertificateResponse response = findCertificateService.execute(studentCode);
 
             // then
             assertThat(response.certificates()).hasSize(1);


### PR DESCRIPTION
## 📋 작업 내용
> DB에 저장되는 항목명과 하드코딩된 상수의 값이 달랐던 문제를 수정하였고 또한, 삭제 로직에서 필요한 로직이 누락되어 있던 문제를 수정하였습니다.또한, #41 에서 논의된 내용을 기존 ``CertificateWebAdapter``에 반영하였습니다

## 🤝 리뷰 시 참고사항
> #42 먼저 Merge 되도록 진행하는 것이 좋을 것 같습니다

## ✅ 체크리스트
- [x] 이 작업으로 인해 변경이 필요한 문서를 작성 또는 수정했나요? (e.g. `README`, `.env.example`)
- [x] 작업한 코드가 정상적으로 동작하는지 확인했나요?
- [x] 작업한 코드에 대한 테스트 코드를 작성하거나 수정했나요?
- [x] Merge 대상 브랜치를 올바르게 설정했나요?
- [x] 해당 PR과 관련 없는 작업이 포함되지는 않았나요?
- [x] PR의 올바른 라벨과 리뷰어를 설정했나요?