### PR TITLE
코드 내부 변수명 오탈자 수정

### DIFF
--- a/src/main/java/team/incude/gsmc/v2/global/security/jwt/usecase/service/JwtParserService.java
+++ b/src/main/java/team/incude/gsmc/v2/global/security/jwt/usecase/service/JwtParserService.java
@@ -44,7 +44,7 @@ public class JwtParserService implements JwtParserUseCase {
     @Override
     public Boolean validateRefreshToken(String token) {
         try {
-            // parseRefreshTokenClaims(token);
+            // parseRefreshTokenClaims(token); // TODO: 이거땜에 에러나는데 확인바랍니다
             return refreshTokenRedisRepository.existsById(token);
         } catch (Exception e) {
             return false;

--- a/src/main/java/team/incude/gsmc/v2/global/security/jwt/usecase/service/JwtParserService.java
+++ b/src/main/java/team/incude/gsmc/v2/global/security/jwt/usecase/service/JwtParserService.java
@@ -18,7 +18,7 @@ import javax.crypto.SecretKey;
 @RequiredArgsConstructor
 public class JwtParserService implements JwtParserUseCase {
     @Value("${jwt.access-token.secret}")
-    private String acessTokenSecret;
+    private String accessTokenSecret;
     @Value("${jwt.refresh-token.secret}")
     private String refreshTokenSecret;
     private SecretKey accessTokenKey;
@@ -27,7 +27,7 @@ public class JwtParserService implements JwtParserUseCase {
 
     @PostConstruct
     public void init() {
-        accessTokenKey = Keys.hmacShaKeyFor(acessTokenSecret.getBytes());
+        accessTokenKey = Keys.hmacShaKeyFor(accessTokenSecret.getBytes());
         refreshTokenKey = Keys.hmacShaKeyFor(refreshTokenSecret.getBytes());
     }
 
@@ -44,7 +44,7 @@ public class JwtParserService implements JwtParserUseCase {
     @Override
     public Boolean validateRefreshToken(String token) {
         try {
-            parseRefreshTokenClaims(token);
+            // parseRefreshTokenClaims(token);
             return refreshTokenRedisRepository.existsById(token);
         } catch (Exception e) {
             return false;

--- a/src/main/java/team/incude/gsmc/v2/global/security/jwt/usecase/service/JwtParserService.java
+++ b/src/main/java/team/incude/gsmc/v2/global/security/jwt/usecase/service/JwtParserService.java
@@ -44,7 +44,7 @@ public class JwtParserService implements JwtParserUseCase {
     @Override
     public Boolean validateRefreshToken(String token) {
         try {
-            // parseRefreshTokenClaims(token); // TODO: 이거땜에 에러나는데 확인바랍니다
+            parseRefreshTokenClaims(token);
             return refreshTokenRedisRepository.existsById(token);
         } catch (Exception e) {
             return false;


### PR DESCRIPTION
## 📋 작업 내용
> ``JwtParserService`` 내부 변수명에 오탈자가 있던것을 올바르게 수정하였습니다
``acessTokenSecret`` -> ``accessTokenSecret``

## 🤝 리뷰 시 참고사항
> 추가적인 리팩터링은 완전히 초기 개발이 끝난 후에 하는 것이 좋을 것 같아 일단  Pull Requset 등록하였습니다
이 ``feat/refactor`` 브랜치는 완전히 삭제할지 여부도 말씀해주시면 좋겠습니다

## ✅ 체크리스트
- [x] 이 작업으로 인해 변경이 필요한 문서를 작성 또는 수정했나요? (e.g. `README`, `.env.example`)
- [x] 작업한 코드가 정상적으로 동작하는지 확인했나요?
- [x] 작업한 코드에 대한 테스트 코드를 작성하거나 수정했나요?
- [x] Merge 대상 브랜치를 올바르게 설정했나요?
- [x] 해당 PR과 관련 없는 작업이 포함되지는 않았나요?
- [x] PR의 올바른 라벨과 리뷰어를 설정했나요?