### PR TITLE
유효하지 않은 학생 사용자 예외명 구체화

### DIFF
--- a/src/main/java/team/incude/gsmc/v2/domain/auth/application/usecase/service/SignUpService.java
+++ b/src/main/java/team/incude/gsmc/v2/domain/auth/application/usecase/service/SignUpService.java
@@ -38,7 +38,7 @@ public class SignUpService implements SignUpUseCase {
             throw new MemberExistException();
         }
 
-        StudentDetail existedStudentDetail = studentDetailPersistencePort.findStudentDetailByStudentCode(parsingEmail(email));
+        StudentDetail existedStudentDetail = studentDetailPersistencePort.findStudentDetailByStudentCodeWithLock(parsingEmail(email));
 
         Member member = Member.builder()
                 .email(email)
@@ -67,11 +67,8 @@ public class SignUpService implements SignUpUseCase {
         if (!email.startsWith("s") || !email.endsWith("@gsm.hs.kr")) {
             throw new EmailFormatInvalidException();
         }
-
         String studentId = email.substring(1, email.indexOf("@"));
         try {
-            //Integer studentCode = Integer.parseInt(studentId);
-            //return studentCode;
             return studentId;
         } catch (NumberFormatException e) {
             throw new EmailFormatInvalidException();

--- a/src/main/java/team/incude/gsmc/v2/domain/member/application/port/StudentDetailPersistencePort.java
+++ b/src/main/java/team/incude/gsmc/v2/domain/member/application/port/StudentDetailPersistencePort.java
@@ -13,6 +13,8 @@ import java.util.List;
 public interface StudentDetailPersistencePort {
     StudentDetail findStudentDetailByStudentCode(String studentCode);
 
+    StudentDetail findStudentDetailByStudentCodeWithLock(String studentCode);
+
     StudentDetail findStudentDetailByMemberEmail(String email);
 
     List<StudentDetail> findStudentDetailByGradeAndClassNumber(Integer grade, Integer classNumber);

--- a/src/main/java/team/incude/gsmc/v2/domain/member/exception/MemberInvalidException.java
+++ b/src/main/java/team/incude/gsmc/v2/domain/member/exception/MemberInvalidException.java
@@ -5,6 +5,6 @@ import team.incude.gsmc.v2.global.error.exception.GsmcException;
 
 public class MemberInvalidException extends GsmcException {
     public MemberInvalidException() {
-        super(ErrorCode.MEMBER_INVALID);
+        super(ErrorCode.STUDENT_MEMBER_INVALID);
     }
 }

--- a/src/main/java/team/incude/gsmc/v2/domain/member/persistence/StudentDetailPersistenceAdapter.java
+++ b/src/main/java/team/incude/gsmc/v2/domain/member/persistence/StudentDetailPersistenceAdapter.java
@@ -2,6 +2,7 @@ package team.incude.gsmc.v2.domain.member.persistence;
 
 import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.LockModeType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -38,6 +39,17 @@ public class StudentDetailPersistenceAdapter implements StudentDetailPersistence
                 jpaQueryFactory
                         .selectFrom(studentDetailJpaEntity)
                         .where(studentDetailJpaEntity.studentCode.eq(studentCode))
+                        .fetchOne()
+        ).map(studentDetailMapper::toDomain).orElseThrow(MemberInvalidException::new);
+    }
+
+    @Override
+    public StudentDetail findStudentDetailByStudentCodeWithLock(String studentCode) {
+        return Optional.ofNullable(
+                jpaQueryFactory
+                        .selectFrom(studentDetailJpaEntity)
+                        .where(studentDetailJpaEntity.studentCode.eq(studentCode))
+                        .setLockMode(LockModeType.PESSIMISTIC_WRITE)
                         .fetchOne()
         ).map(studentDetailMapper::toDomain).orElseThrow(MemberInvalidException::new);
     }

--- a/src/main/java/team/incude/gsmc/v2/global/error/ErrorCode.java
+++ b/src/main/java/team/incude/gsmc/v2/global/error/ErrorCode.java
@@ -39,7 +39,7 @@ public enum ErrorCode {
     EMAIL_AUTH_ATTEMPT_EXCEEDED("Email Auth Attempt Exceeded", HttpStatus.TOO_MANY_REQUESTS.value()),
     PASSWORD_INVALID("Password Invalid", HttpStatus.UNAUTHORIZED.value()),
     AUTHENTICATION_NOT_FOUND("Authentication Object not found", HttpStatus.FORBIDDEN.value()),
-    MEMBER_INVALID("No Member Found", HttpStatus.UNAUTHORIZED.value()),
+    MEMBER_INVALID("Member Invalid", HttpStatus.UNAUTHORIZED.value()),
 
     // Email Authentication
     EMAIL_FORMAT_INVALID("Email Format Invalid", HttpStatus.UNAUTHORIZED.value()),

--- a/src/main/java/team/incude/gsmc/v2/global/error/ErrorCode.java
+++ b/src/main/java/team/incude/gsmc/v2/global/error/ErrorCode.java
@@ -39,7 +39,7 @@ public enum ErrorCode {
     EMAIL_AUTH_ATTEMPT_EXCEEDED("Email Auth Attempt Exceeded", HttpStatus.TOO_MANY_REQUESTS.value()),
     PASSWORD_INVALID("Password Invalid", HttpStatus.UNAUTHORIZED.value()),
     AUTHENTICATION_NOT_FOUND("Authentication Object not found", HttpStatus.FORBIDDEN.value()),
-    MEMBER_INVALID("Member Invalid", HttpStatus.UNAUTHORIZED.value()),
+    STUDENT_MEMBER_INVALID("Member Invalid", HttpStatus.UNAUTHORIZED.value()),
 
     // Email Authentication
     EMAIL_FORMAT_INVALID("Email Format Invalid", HttpStatus.UNAUTHORIZED.value()),


### PR DESCRIPTION
## 📋 작업 내용
> 정확히 어떠한 예외상황인지 알기 어려웠던 예외상황의 설명과 변수명을 구체화하였습니다

## 🤝 리뷰 시 참고사항
> 해당 예외가 발생하는 상황이 예를 들어 ``tb_student_detail`` 테이블 조회를 할 때 올바르지 않은 파라미터(e.g. ``24099``)로 조회하였을 시 특수한 비즈니스 요구사항을 반영하여 **404 Not Found** 대신 **401 Unauthorized**을 반환하도록 설계되었습니다.변경된 내용이 그러한 상황을 잘 반영하였는지 검토해주시면 감사하겠습니다

## ✅ 체크리스트
- [x] 이 작업으로 인해 변경이 필요한 문서를 작성 또는 수정했나요? (e.g. `README`, `.env.example`)
- [x] 작업한 코드가 정상적으로 동작하는지 확인했나요?
- [x] 작업한 코드에 대한 테스트 코드를 작성하거나 수정했나요?
- [x] Merge 대상 브랜치를 올바르게 설정했나요?
- [x] 해당 PR과 관련 없는 작업이 포함되지는 않았나요?
- [x] PR의 올바른 라벨과 리뷰어를 설정했나요?