### PR TITLE
회원가입 시 비관적 락 적용

### DIFF
--- a/src/main/java/team/incude/gsmc/v2/domain/auth/application/usecase/service/SignUpService.java
+++ b/src/main/java/team/incude/gsmc/v2/domain/auth/application/usecase/service/SignUpService.java
@@ -38,7 +38,7 @@ public class SignUpService implements SignUpUseCase {
             throw new MemberExistException();
         }
 
-        StudentDetail existedStudentDetail = studentDetailPersistencePort.findStudentDetailByStudentCode(parsingEmail(email));
+        StudentDetail existedStudentDetail = studentDetailPersistencePort.findStudentDetailByStudentCodeWithLock(parsingEmail(email));
 
         Member member = Member.builder()
                 .email(email)
@@ -67,11 +67,8 @@ public class SignUpService implements SignUpUseCase {
         if (!email.startsWith("s") || !email.endsWith("@gsm.hs.kr")) {
             throw new EmailFormatInvalidException();
         }
-
         String studentId = email.substring(1, email.indexOf("@"));
         try {
-            //Integer studentCode = Integer.parseInt(studentId);
-            //return studentCode;
             return studentId;
         } catch (NumberFormatException e) {
             throw new EmailFormatInvalidException();

--- a/src/main/java/team/incude/gsmc/v2/domain/member/application/port/StudentDetailPersistencePort.java
+++ b/src/main/java/team/incude/gsmc/v2/domain/member/application/port/StudentDetailPersistencePort.java
@@ -13,6 +13,8 @@ import java.util.List;
 public interface StudentDetailPersistencePort {
     StudentDetail findStudentDetailByStudentCode(String studentCode);
 
+    StudentDetail findStudentDetailByStudentCodeWithLock(String studentCode);
+
     StudentDetail findStudentDetailByMemberEmail(String email);
 
     List<StudentDetail> findStudentDetailByGradeAndClassNumber(Integer grade, Integer classNumber);

--- a/src/main/java/team/incude/gsmc/v2/domain/member/persistence/StudentDetailPersistenceAdapter.java
+++ b/src/main/java/team/incude/gsmc/v2/domain/member/persistence/StudentDetailPersistenceAdapter.java
@@ -2,6 +2,7 @@ package team.incude.gsmc.v2.domain.member.persistence;
 
 import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.LockModeType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -38,6 +39,17 @@ public class StudentDetailPersistenceAdapter implements StudentDetailPersistence
                 jpaQueryFactory
                         .selectFrom(studentDetailJpaEntity)
                         .where(studentDetailJpaEntity.studentCode.eq(studentCode))
+                        .fetchOne()
+        ).map(studentDetailMapper::toDomain).orElseThrow(MemberInvalidException::new);
+    }
+
+    @Override
+    public StudentDetail findStudentDetailByStudentCodeWithLock(String studentCode) {
+        return Optional.ofNullable(
+                jpaQueryFactory
+                        .selectFrom(studentDetailJpaEntity)
+                        .where(studentDetailJpaEntity.studentCode.eq(studentCode))
+                        .setLockMode(LockModeType.PESSIMISTIC_WRITE)
                         .fetchOne()
         ).map(studentDetailMapper::toDomain).orElseThrow(MemberInvalidException::new);
     }


### PR DESCRIPTION
## 📋 작업 내용
> #73 문제를 해결하기 위하여 회원가입 시 수정되는 학생 세부정보 Entity에 비관적 락을 적용하였습니다.

## 🤝 리뷰 시 참고사항
> 추후 관련 문제가 재발할 수도 있는데 지속적인 테스트 케이스 추가와 추적이 필요할 것 같습니다.
또한, @jihoonwjj 님이 ``auth`` 모델의 단위테스트를 작성하시고 있는 걸로 아는데 해당 부분도 수정이 필요할 것 같습니다.

## ✅ 체크리스트
- [x] 이 작업으로 인해 변경이 필요한 문서를 작성 또는 수정했나요? (e.g. `README`, `.env.example`)
- [x] 작업한 코드가 정상적으로 동작하는지 확인했나요?
- [x] 작업한 코드에 대한 테스트 코드를 작성하거나 수정했나요?
- [x] Merge 대상 브랜치를 올바르게 설정했나요?
- [x] 해당 PR과 관련 없는 작업이 포함되지는 않았나요?
- [x] PR의 올바른 라벨과 리뷰어를 설정했나요?