### PR TITLE
``NonUniqueResultException`` 예외 핸들링 추가

### DIFF
--- a/src/main/java/team/incude/gsmc/v2/global/error/handler/GlobalExceptionHandler.java
+++ b/src/main/java/team/incude/gsmc/v2/global/error/handler/GlobalExceptionHandler.java
@@ -1,5 +1,7 @@
 package team.incude.gsmc.v2.global.error.handler;
 
+import org.hibernate.NonUniqueResultException;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -14,5 +16,12 @@ public class GlobalExceptionHandler {
         return ResponseEntity
                 .status(e.getErrorCode().getStatus())
                 .body(new ErrorResponse(e.getErrorCode().getMessage(), e.getErrorCode().getStatus()));
+    }
+
+    @ExceptionHandler(NonUniqueResultException.class)
+    public ResponseEntity<ErrorResponse> handleNonUniqueResultException(NonUniqueResultException e) {
+        return ResponseEntity
+                .status(HttpStatus.CONFLICT)
+                .body(new ErrorResponse("Duplicate results detected, Please check your request", HttpStatus.CONFLICT.value()));
     }
 }


### PR DESCRIPTION
## 📋 작업 내용
> RDB의 ``UNIQUE`` 제약조건을 위반하였을 때 클라이언트에 **500 Internal Server Error**을 반환하던 것을 조금 더 사용자 친화적으로 **409 Conflic**와 에러 메세지를 반환하도록 핸들링하였습니다

## 🤝 리뷰 시 참고사항

## ✅ 체크리스트
- [x] 이 작업으로 인해 변경이 필요한 문서를 작성 또는 수정했나요? (e.g. `README`, `.env.example`)
- [x] 작업한 코드가 정상적으로 동작하는지 확인했나요?
- [x] 작업한 코드에 대한 테스트 코드를 작성하거나 수정했나요?
- [x] Merge 대상 브랜치를 올바르게 설정했나요?
- [x] 해당 PR과 관련 없는 작업이 포함되지는 않았나요?
- [x] PR의 올바른 라벨과 리뷰어를 설정했나요?