### PR TITLE
유틸리티,매퍼,전역 예외처리,AWS S3 관련 인터페이스/클래스 JavaDoc 주석추가

### DIFF
--- a/src/main/java/team/incude/gsmc/v2/domain/evidence/application/port/S3Port.java
+++ b/src/main/java/team/incude/gsmc/v2/domain/evidence/application/port/S3Port.java
@@ -1,8 +1,21 @@
 package team.incude.gsmc.v2.domain.evidence.application.port;
 
+
 import java.io.InputStream;
 import java.util.concurrent.CompletableFuture;
 
+/**
+ * AWS S3와의 파일 업로드 및 삭제 기능을 정의하는 포트 인터페이스입니다.
+ * <p>도메인 계층에서 S3에 의존하지 않고 파일 저장 및 삭제 작업을 추상화하여 사용할 수 있도록 설계되었습니다.
+ * <p>비동기 방식으로 동작하며, {@link java.util.concurrent.CompletableFuture}를 통해 결과를 반환합니다.
+ * 주요 기능:
+ * <ul>
+ *   <li>{@code uploadFile(String fileName, InputStream fileInputStream)} - 파일 업로드</li>
+ *   <li>{@code deleteFile(String fileName)} - 파일 삭제</li>
+ * </ul>
+ * 이 포트는 실제 구현체(S3Adapter 등)를 통해 외부 시스템과 통신합니다.
+ * @author snowykte0426
+ */
 public interface S3Port {
     CompletableFuture<String> uploadFile(String fileName, InputStream fileInputStream);
 

--- a/src/main/java/team/incude/gsmc/v2/global/error/ErrorCode.java
+++ b/src/main/java/team/incude/gsmc/v2/global/error/ErrorCode.java
@@ -4,6 +4,22 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.springframework.http.HttpStatus;
 
+/**
+ * 애플리케이션 전반에서 사용되는 표준 오류 코드 열거형입니다.
+ * <p>각 오류 항목은 오류 메시지와 HTTP 상태 코드를 함께 정의하며,
+ * {@link team.incude.gsmc.v2.global.error.handler.GlobalExceptionHandler}에서 참조되어 일관된 오류 응답을 제공합니다.
+ * <p>분류:
+ * <ul>
+ *   <li>AWS S3: 업로드/삭제/파일 유효성 오류</li>
+ *   <li>Certificate: 자격증 도메인 관련 오류</li>
+ *   <li>Score: 점수 유효성, 증빙자료 요구 등 도메인 제약 오류</li>
+ *   <li>Member/Auth: 사용자 인증/인가 및 관련 서비스 오류</li>
+ *   <li>Evidence: 각 증빙자료 유형별 처리 오류</li>
+ *   <li>Sheet: 시트 생성 실패</li>
+ * </ul>
+ * 이 Enum은 API 오류 응답의 표준화 및 유지보수성을 향상시키기 위해 사용됩니다.
+ * @author snowykte0426, jihoonwjj, suuuuuuminnnnnn
+ */
 @Getter
 @AllArgsConstructor
 public enum ErrorCode {

--- a/src/main/java/team/incude/gsmc/v2/global/error/data/response/ErrorResponse.java
+++ b/src/main/java/team/incude/gsmc/v2/global/error/data/response/ErrorResponse.java
@@ -1,4 +1,14 @@
 package team.incude.gsmc.v2.global.error.data.response;
 
+
+/**
+ * API 오류 응답 본문을 나타내는 레코드입니다.
+ * <p>클라이언트에게 전달되는 표준 오류 메시지 형식으로,
+ * 오류 메시지와 HTTP 상태 코드를 포함합니다.
+ * 이 응답 객체는 {@link team.incude.gsmc.v2.global.error.handler.GlobalExceptionHandler}에서 예외 처리 시 반환됩니다.
+ * @param message 클라이언트에 전달할 오류 메시지
+ * @param httpStatus HTTP 상태 코드
+ * @author snowykte0426
+ */
 public record ErrorResponse(String message, int httpStatus) {
 }

--- a/src/main/java/team/incude/gsmc/v2/global/error/exception/GsmcException.java
+++ b/src/main/java/team/incude/gsmc/v2/global/error/exception/GsmcException.java
@@ -3,6 +3,14 @@ package team.incude.gsmc.v2.global.error.exception;
 import lombok.Getter;
 import team.incude.gsmc.v2.global.error.ErrorCode;
 
+/**
+ * GSMC 애플리케이션의 공통 런타임 예외 클래스입니다.
+ * <p>모든 커스텀 예외 클래스는 이 클래스를 상속받아 {@link ErrorCode}를 포함하도록 구성됩니다.
+ * 이를 통해 예외 발생 시 일관된 메시지와 상태 코드를 전달할 수 있으며,
+ * {@link team.incude.gsmc.v2.global.error.handler.GlobalExceptionHandler}에서 처리됩니다.
+ * <p>이 예외는 메시지를 자동으로 {@code errorCode.getMessage()}로 설정합니다.
+ * @author snowykte0426
+ */
 @Getter
 public class GsmcException extends RuntimeException {
     private final ErrorCode errorCode;

--- a/src/main/java/team/incude/gsmc/v2/global/error/handler/GlobalExceptionHandler.java
+++ b/src/main/java/team/incude/gsmc/v2/global/error/handler/GlobalExceptionHandler.java
@@ -8,9 +8,28 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import team.incude.gsmc.v2.global.error.data.response.ErrorResponse;
 import team.incude.gsmc.v2.global.error.exception.GsmcException;
 
+/**
+ * 애플리케이션 전역에서 발생하는 예외를 처리하는 예외 핸들러입니다.
+ * <p>{@code @ControllerAdvice}를 통해 모든 컨트롤러에서 발생하는 예외를 가로채고,
+ * 정의된 예외 타입에 따라 적절한 HTTP 응답을 반환합니다.
+ * <p>지원하는 예외:
+ * <ul>
+ *   <li>{@link GsmcException} - 커스텀 예외 및 도메인 전용 예외</li>
+ *   <li>{@link NonUniqueResultException} - JPA 조회 시 결과 중복 예외</li>
+ * </ul>
+ * 응답 형식은 모두 {@link team.incude.gsmc.v2.global.error.data.response.ErrorResponse}로 통일되어 있습니다.
+ * @author snowykte0426
+ */
 @ControllerAdvice
 public class GlobalExceptionHandler {
 
+    /**
+     * {@link GsmcException} 처리 메서드.
+     * <p>커스텀 예외에서 정의된 {@link team.incude.gsmc.v2.global.error.ErrorCode}를 기반으로
+     * HTTP 상태 코드와 메시지를 포함한 오류 응답을 생성합니다.
+     * @param e 처리할 GsmcException
+     * @return 표준화된 오류 응답
+     */
     @ExceptionHandler(GsmcException.class)
     public ResponseEntity<ErrorResponse> handleGroomException(GsmcException e) {
         return ResponseEntity
@@ -18,6 +37,13 @@ public class GlobalExceptionHandler {
                 .body(new ErrorResponse(e.getErrorCode().getMessage(), e.getErrorCode().getStatus()));
     }
 
+    /**
+     * {@link NonUniqueResultException} 처리 메서드.
+     * <p>JPA 조회 시 단건 결과를 기대했지만 복수 결과가 반환된 경우 발생합니다.
+     * HTTP 상태 코드 409(CONFLICT)와 함께 오류 메시지를 응답합니다.
+     * @param e 처리할 NonUniqueResultException
+     * @return 충돌 오류 응답
+     */
     @ExceptionHandler(NonUniqueResultException.class)
     public ResponseEntity<ErrorResponse> handleNonUniqueResultException(NonUniqueResultException e) {
         return ResponseEntity

--- a/src/main/java/team/incude/gsmc/v2/global/mapper/GenericMapper.java
+++ b/src/main/java/team/incude/gsmc/v2/global/mapper/GenericMapper.java
@@ -1,5 +1,13 @@
 package team.incude.gsmc.v2.global.mapper;
 
+/**
+ * 도메인 객체와 JPA 엔티티 간의 양방향 매핑을 정의하는 제네릭 인터페이스입니다.
+ * <p>이 인터페이스는 매퍼 구현체에서 공통적으로 사용하는 구조를 추상화하며,
+ * 도메인 모델과 영속성 계층의 엔티티 간 변환 로직을 표준화합니다.
+ * @param <ENTITY> 변환 대상이 되는 JPA 엔티티 타입
+ * @param <DOMAIN> 변환 대상이 되는 도메인 객체 타입
+ * @author snowykte0426
+ */
 public interface GenericMapper<ENTITY, DOMAIN> {
     ENTITY toEntity(DOMAIN domain);
 

--- a/src/main/java/team/incude/gsmc/v2/global/thirdparty/aws/exception/S3DeleteFailedException.java
+++ b/src/main/java/team/incude/gsmc/v2/global/thirdparty/aws/exception/S3DeleteFailedException.java
@@ -3,6 +3,13 @@ package team.incude.gsmc.v2.global.thirdparty.aws.exception;
 import team.incude.gsmc.v2.global.error.ErrorCode;
 import team.incude.gsmc.v2.global.error.exception.GsmcException;
 
+/**
+ * AWS S3에서 파일 삭제에 실패했을 때 발생하는 예외입니다.
+ * <p>비동기 삭제 작업 중 예기치 못한 오류가 발생하거나 S3 응답이 실패 상태인 경우에 이 예외가 사용됩니다.
+ * {@link ErrorCode#S3_DELETE_FAILED}에 매핑되어 클라이언트에 적절한 오류 메시지를 전달합니다.
+ * <p>주로 {@link team.incude.gsmc.v2.global.thirdparty.aws.s3.usecase.service.FileDeleteService} 내에서 S3 비동기 삭제 실패 시 발생합니다.
+ * @author snowykte0426
+ */
 public class S3DeleteFailedException extends GsmcException {
     public S3DeleteFailedException() {
         super(ErrorCode.S3_DELETE_FAILED);

--- a/src/main/java/team/incude/gsmc/v2/global/thirdparty/aws/exception/S3UploadFailedException.java
+++ b/src/main/java/team/incude/gsmc/v2/global/thirdparty/aws/exception/S3UploadFailedException.java
@@ -3,6 +3,13 @@ package team.incude.gsmc.v2.global.thirdparty.aws.exception;
 import team.incude.gsmc.v2.global.error.ErrorCode;
 import team.incude.gsmc.v2.global.error.exception.GsmcException;
 
+/**
+ * AWS S3에 파일 업로드가 실패했을 때 발생하는 예외입니다.
+ * <p>파일 스트림 처리 오류, 네트워크 장애, 권한 문제 등으로 인해 업로드 작업이 정상적으로 완료되지 않은 경우 사용됩니다.
+ * {@link ErrorCode#S3_UPLOAD_FAILED}에 매핑되어 클라이언트에게 업로드 실패 사유를 명확히 전달합니다.
+ * <p>주로 {@link team.incude.gsmc.v2.global.thirdparty.aws.s3.usecase.service.FileUploadService}에서 파일 업로드 중 예외 발생 시 던져집니다.
+ * @author snowykte0426
+ */
 public class S3UploadFailedException extends GsmcException {
     public S3UploadFailedException() {
         super(ErrorCode.S3_UPLOAD_FAILED);

--- a/src/main/java/team/incude/gsmc/v2/global/thirdparty/aws/s3/S3Adapter.java
+++ b/src/main/java/team/incude/gsmc/v2/global/thirdparty/aws/s3/S3Adapter.java
@@ -10,6 +10,20 @@ import team.incude.gsmc.v2.global.thirdparty.aws.s3.usecase.FileUploadUseCase;
 import java.io.InputStream;
 import java.util.concurrent.CompletableFuture;
 
+/**
+ * AWS S3 파일 연동을 위한 어댑터 클래스입니다.
+ *
+ * <p>{@link S3Port}의 구현체로, 파일 업로드 및 삭제 기능을 실제로 수행합니다.
+ * 내부적으로 {@link FileUploadUseCase}, {@link FileDeleteUseCase}를 통해 작업을 위임하며,
+ * 비동기 방식으로 동작하여 {@link CompletableFuture} 형태로 결과를 반환합니다.
+ * <p>{@code @Adapter(direction = PortDirection.OUTBOUND)}로 선언되어 도메인 계층이 외부 시스템에 의존하지 않도록 구성됩니다.
+ * <p>주요 역할:
+ * <ul>
+ *   <li>파일 업로드 요청 위임 및 결과 반환</li>
+ *   <li>파일 삭제 요청 위임 및 처리</li>
+ * </ul>
+ * @author snowykte0426
+ */
 @Adapter(direction = PortDirection.OUTBOUND)
 @RequiredArgsConstructor
 public class S3Adapter implements S3Port {

--- a/src/main/java/team/incude/gsmc/v2/global/thirdparty/aws/s3/config/S3Config.java
+++ b/src/main/java/team/incude/gsmc/v2/global/thirdparty/aws/s3/config/S3Config.java
@@ -8,6 +8,14 @@ import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
 
+
+/**
+ * AWS S3 연동을 위한 비동기 클라이언트 설정 클래스입니다.
+ * <p>{@link S3AsyncClient}를 Spring Bean으로 등록하여 S3 파일 업로드 및 삭제 기능에서 사용할 수 있도록 구성합니다.
+ * <p>액세스 키, 시크릿 키, 리전 정보는 {@code application.yml} 또는 환경 변수로부터 주입됩니다.
+ * <p>이 구성은 AWS SDK v2 기반의 비동기 S3 클라이언트를 사용하여 비동기 I/O 성능을 극대화합니다.
+ * @author snowykte0426
+ */
 @Configuration
 public class S3Config {
 

--- a/src/main/java/team/incude/gsmc/v2/global/thirdparty/aws/s3/usecase/FileDeleteUseCase.java
+++ b/src/main/java/team/incude/gsmc/v2/global/thirdparty/aws/s3/usecase/FileDeleteUseCase.java
@@ -2,6 +2,14 @@ package team.incude.gsmc.v2.global.thirdparty.aws.s3.usecase;
 
 import java.util.concurrent.CompletableFuture;
 
+/**
+ * S3에서 파일을 삭제하는 유스케이스를 정의하는 인터페이스입니다.
+ * <p>파일 이름을 입력받아 해당 파일을 S3 버킷에서 비동기 방식으로 삭제합니다.
+ * 삭제 작업의 결과는 {@link CompletableFuture}를 통해 비동기적으로 처리됩니다.
+ * 이 유스케이스는 어댑터 계층(S3Adapter 등)에서 구현되며,
+ * 도메인 계층이 외부 저장소(S3)에 직접 의존하지 않도록 추상화를 제공합니다.
+ * @author snowykte0426
+ */
 public interface FileDeleteUseCase {
     CompletableFuture<Void> execute(String fileName);
 }

--- a/src/main/java/team/incude/gsmc/v2/global/thirdparty/aws/s3/usecase/FileUploadUseCase.java
+++ b/src/main/java/team/incude/gsmc/v2/global/thirdparty/aws/s3/usecase/FileUploadUseCase.java
@@ -3,6 +3,15 @@ package team.incude.gsmc.v2.global.thirdparty.aws.s3.usecase;
 import java.io.InputStream;
 import java.util.concurrent.CompletableFuture;
 
+
+/**
+ * S3에 파일을 업로드하는 유스케이스를 정의하는 인터페이스입니다.
+ * <p>파일 이름과 입력 스트림을 받아 S3에 비동기 방식으로 파일을 업로드하고,
+ * 업로드된 파일의 URI를 {@link CompletableFuture}를 통해 반환합니다.
+ * 이 인터페이스는 어댑터 계층(S3Adapter 등)에서 구현되며,
+ * 도메인 계층이 파일 업로드 세부 구현에 의존하지 않도록 추상화합니다.
+ * @author snowykte0426
+ */
 public interface FileUploadUseCase {
     CompletableFuture<String> execute(String fileName, InputStream fileInputStream);
 }

--- a/src/main/java/team/incude/gsmc/v2/global/thirdparty/aws/s3/usecase/service/FileDeleteService.java
+++ b/src/main/java/team/incude/gsmc/v2/global/thirdparty/aws/s3/usecase/service/FileDeleteService.java
@@ -12,6 +12,18 @@ import team.incude.gsmc.v2.global.thirdparty.aws.s3.usecase.FileDeleteUseCase;
 
 import java.util.concurrent.CompletableFuture;
 
+/**
+ * AWS S3에서 파일을 삭제하는 유스케이스 구현 클래스입니다.
+ * <p>{@link FileDeleteUseCase}를 구현하며, S3 버킷에 저장된 파일을 비동기 방식으로 삭제합니다.
+ * <p>주요 기능:
+ * <ul>
+ *   <li>S3 버킷과 파일 키를 기반으로 삭제 요청 전송</li>
+ *   <li>삭제 성공 시 로그 기록</li>
+ *   <li>삭제 실패 시 {@link S3DeleteFailedException} 발생</li>
+ * </ul>
+ * 이 서비스는 {@link S3AsyncClient}를 통해 AWS SDK v2 기반 비동기 I/O 처리로 수행됩니다.
+ * @author snowykte0426
+ */
 @Slf4j
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/team/incude/gsmc/v2/global/thirdparty/aws/s3/usecase/service/FileUploadService.java
+++ b/src/main/java/team/incude/gsmc/v2/global/thirdparty/aws/s3/usecase/service/FileUploadService.java
@@ -17,6 +17,19 @@ import java.io.InputStream;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
+/**
+ * 파일을 AWS S3에 비동기 방식으로 업로드하는 유스케이스 구현 클래스입니다.
+ * <p>{@link FileUploadUseCase}를 구현하며, 업로드 대상 파일을 S3에 저장한 후 접근 가능한 URL을 반환합니다.
+ * <p>처리 흐름:
+ * <ul>
+ *   <li>파일 이름에 UUID를 추가해 중복 방지</li>
+ *   <li>{@link FileValidationUtil}을 통해 유효성 검증 수행</li>
+ *   <li>{@link S3AsyncClient}를 사용해 비동기 업로드 실행</li>
+ *   <li>업로드 완료 후, 접근 가능한 S3 URL을 반환</li>
+ * </ul>
+ * <p>예외 발생 시 {@link S3UploadFailedException}을 던지며, 파일 스트림에서의 오류 또는 S3 전송 실패를 감지합니다.
+ * @author snowykte0426
+ */
 @Service
 @RequiredArgsConstructor
 public class FileUploadService implements FileUploadUseCase {

--- a/src/main/java/team/incude/gsmc/v2/global/util/ExtractFileKeyUtil.java
+++ b/src/main/java/team/incude/gsmc/v2/global/util/ExtractFileKeyUtil.java
@@ -6,6 +6,13 @@ import team.incude.gsmc.v2.global.util.exception.InvalidFileUrlException;
 import java.net.MalformedURLException;
 import java.net.URL;
 
+/**
+ * S3 파일 URI에서 파일 키를 추출하는 유틸리티 클래스입니다.
+ * <p>파일 URI 전체에서 경로(Path) 부분을 추출하여 S3 키로 변환합니다.
+ * 유효하지 않은 URL 형식의 입력이 들어올 경우 {@link InvalidFileUrlException}을 발생시킵니다.
+ * <p>{@code @UtilityClass}로 선언되어 정적 메서드만 포함되며 인스턴스화되지 않습니다.
+ * @author snowykte0426
+ */
 @UtilityClass
 public class ExtractFileKeyUtil {
 

--- a/src/main/java/team/incude/gsmc/v2/global/util/FileValidationUtil.java
+++ b/src/main/java/team/incude/gsmc/v2/global/util/FileValidationUtil.java
@@ -7,17 +7,42 @@ import team.incude.gsmc.v2.global.util.exception.FileNameTooLongException;
 import java.io.IOException;
 import java.io.InputStream;
 
+/**
+ * 파일 유효성 검사를 위한 유틸리티 클래스입니다.
+ * <p>S3에 업로드되는 파일의 스트림 유효성 및 URL 길이 제한 등을 검증합니다.
+ * 빈 파일 업로드나 과도하게 긴 파일 경로로 인한 오류를 방지하기 위해 사용됩니다.
+ * <p>{@code @UtilityClass}로 선언되어 정적 유틸 메서드만 포함하며 인스턴스화되지 않습니다.
+ * @author snowykte0426
+ */
 @UtilityClass
 public class FileValidationUtil {
 
     private final int MAX_FILE_URL_LENGTH = 255;
 
+    /**
+     * S3 업로드 대상 파일의 URL 길이를 검증합니다.
+     * <p>버킷 이름, 리전, 파일 이름으로 구성된 전체 URL이 최대 길이를 초과할 경우 예외를 발생시킵니다.
+     * @param bucketName S3 버킷 이름
+     * @param region 리전 정보
+     * @param fileName 파일 이름
+     * @throws FileNameTooLongException URL 길이가 허용 범위를 초과할 경우
+     */
     private void validateFileName(String bucketName, String region, String fileName) {
         if (String.format("https://%s.s3.%s.amazonaws.com/%s", bucketName, region, fileName).length() > MAX_FILE_URL_LENGTH) {
             throw new FileNameTooLongException();
         }
     }
 
+    /**
+     * 파일 스트림 및 파일 이름 유효성을 검증합니다.
+     * <p>빈 파일인지 확인한 후, 파일 이름의 S3 URL 길이 제한을 검사합니다.
+     * @param inputStream 파일 입력 스트림
+     * @param bucketName S3 버킷 이름
+     * @param region 리전 정보
+     * @param fileName 파일 이름
+     * @throws EmptyFileException 파일이 비어 있거나 스트림 처리 중 오류가 발생한 경우
+     * @throws FileNameTooLongException 파일 이름으로 구성된 URL 길이가 허용 범위를 초과한 경우
+     */
     public void validateFile(InputStream inputStream, String bucketName, String region, String fileName) {
         try {
             if (inputStream.available() == 0) {

--- a/src/main/java/team/incude/gsmc/v2/global/util/SimulateScoreUtil.java
+++ b/src/main/java/team/incude/gsmc/v2/global/util/SimulateScoreUtil.java
@@ -1,3 +1,4 @@
+
 package team.incude.gsmc.v2.global.util;
 
 import lombok.experimental.UtilityClass;
@@ -6,6 +7,16 @@ import reactor.util.function.Tuple4;
 
 import java.util.Map;
 
+
+/**
+ * 전공, 인문, 외국어 영역별 입력 데이터를 기반으로 모의 점수를 계산하는 유틸리티 클래스입니다.
+ * <p>{@link #simulateScore(...)} 메서드를 중심으로 가중치 맵을 활용하여 세부 항목을 정량화하고,
+ * 총합 점수 및 영역별 점수를 튜플 형태로 반환합니다.
+ * <p>클라이언트에서의 시뮬레이션 요청 처리 및 점수 예측 기능 구현에 활용됩니다.
+ * 계산 방식은 각 영역의 기준 점수, 상한값, 가중치 등을 고려하여 설계되어 있습니다.
+ * {@code @UtilityClass}로 선언되어 인스턴스화가 불가능하며, 모든 메서드는 정적(static)으로 제공됩니다.
+ * @author snowykte0426
+ */
 @UtilityClass
 public class SimulateScoreUtil {
 

--- a/src/main/java/team/incude/gsmc/v2/global/util/SnakeKebabToCamelCaseConverterUtil.java
+++ b/src/main/java/team/incude/gsmc/v2/global/util/SnakeKebabToCamelCaseConverterUtil.java
@@ -2,9 +2,18 @@ package team.incude.gsmc.v2.global.util;
 
 import lombok.experimental.UtilityClass;
 
+/**
+ * snake_case 또는 kebab-case 문자열을 camelCase 형식으로 변환하는 유틸리티 클래스입니다.
+ * <p>주로 JSON 키, 프로퍼티 이름 등에서 스네이크/케밥 케이스로 작성된 문자열을 Java 객체의 필드 명명 규칙인 camelCase로 변환할 때 사용됩니다.
+ * <p>{@code @UtilityClass}로 선언되어 정적 메서드만 포함하며 인스턴스화되지 않습니다.
+ * <p>사용 예시:
+ * <pre>
+ *   toCamelCase("example_string-key") // "exampleStringKey"
+ * </pre>
+ * @author snowykte0426
+ */
 @UtilityClass
 public class SnakeKebabToCamelCaseConverterUtil {
-
     public String toCamelCase(String input) {
         if (input == null || input.isEmpty()) {
             return input;

--- a/src/main/java/team/incude/gsmc/v2/global/util/ValueLimiterUtil.java
+++ b/src/main/java/team/incude/gsmc/v2/global/util/ValueLimiterUtil.java
@@ -2,6 +2,13 @@ package team.incude.gsmc.v2.global.util;
 
 import lombok.experimental.UtilityClass;
 
+/**
+ * 값이 제한 범위를 초과하는지 여부를 검사하는 유틸리티 클래스입니다.
+ * <p>주로 점수 입력 시 최대 허용 값을 초과하는지 확인하는 데 사용되며,
+ * 불필요한 조건문 중복을 줄이기 위한 단순 비교 유틸 메서드를 제공합니다.
+ * <p>{@code @UtilityClass}로 선언되어 정적 메서드만 포함되며 인스턴스화되지 않습니다.
+ * @author snowykte0426
+ */
 @UtilityClass
 public class ValueLimiterUtil {
     public boolean isExceedingLimit(int value, int maxLimit) {

--- a/src/main/java/team/incude/gsmc/v2/global/util/exception/EmptyFileException.java
+++ b/src/main/java/team/incude/gsmc/v2/global/util/exception/EmptyFileException.java
@@ -3,6 +3,14 @@ package team.incude.gsmc.v2.global.util.exception;
 import team.incude.gsmc.v2.global.error.ErrorCode;
 import team.incude.gsmc.v2.global.error.exception.GsmcException;
 
+
+/**
+ * 업로드된 파일이 비어 있을 경우 발생하는 예외입니다.
+ * <p>파일 스트림이 비어 있거나 null인 경우 유효성 검사에서 이 예외가 발생합니다.
+ * {@link ErrorCode#FILE_IS_EMPTY}에 매핑되어 클라이언트에게 적절한 오류 메시지를 전달합니다.
+ * <p>주로 {@link team.incude.gsmc.v2.global.util.FileValidationUtil#validateFile}에서 사용됩니다.
+ * @author snowykte0426
+ */
 public class EmptyFileException extends GsmcException {
     public EmptyFileException() {
         super(ErrorCode.FILE_IS_EMPTY);

--- a/src/main/java/team/incude/gsmc/v2/global/util/exception/FileNameTooLongException.java
+++ b/src/main/java/team/incude/gsmc/v2/global/util/exception/FileNameTooLongException.java
@@ -3,6 +3,13 @@ package team.incude.gsmc.v2.global.util.exception;
 import team.incude.gsmc.v2.global.error.ErrorCode;
 import team.incude.gsmc.v2.global.error.exception.GsmcException;
 
+/**
+ * S3 업로드 시 파일 이름(전체 URL 포함)이 허용된 길이를 초과한 경우 발생하는 예외입니다.
+ * <p>파일 이름이 너무 길어 S3 URL 형식으로 구성할 때 {@code 255자}를 초과하면 이 예외가 발생합니다.
+ * {@link ErrorCode#FILE_NAME_TOO_LONG}에 매핑되어 클라이언트에게 적절한 오류 메시지를 전달합니다.
+ * <p>주로 {@link team.incude.gsmc.v2.global.util.FileValidationUtil} 내부에서 검증 시 사용됩니다.
+ * @author snowykte0426
+ */
 public class FileNameTooLongException extends GsmcException {
   public FileNameTooLongException() {
     super(ErrorCode.FILE_NAME_TOO_LONG);

--- a/src/main/java/team/incude/gsmc/v2/global/util/exception/InvalidFileUrlException.java
+++ b/src/main/java/team/incude/gsmc/v2/global/util/exception/InvalidFileUrlException.java
@@ -3,6 +3,13 @@ package team.incude.gsmc.v2.global.util.exception;
 import team.incude.gsmc.v2.global.error.ErrorCode;
 import team.incude.gsmc.v2.global.error.exception.GsmcException;
 
+/**
+ * 유효하지 않은 파일 URI가 감지되었을 때 발생하는 예외입니다.
+ * <p>파일 삭제, 접근 등의 과정에서 URI 형식이 잘못되었거나 유효하지 않을 경우 이 예외가 발생합니다.
+ * {@link ErrorCode#INVALID_FILE_URI}에 매핑되어 클라이언트에게 적절한 오류 응답을 제공합니다.
+ * <p>주로 {@code ExtractFileKeyUtil} 등의 파일 관련 유틸리티에서 사용됩니다.
+ * @author snowykte0426
+ */
 public class InvalidFileUrlException extends GsmcException {
     public InvalidFileUrlException() {
         super(ErrorCode.INVALID_FILE_URI);


### PR DESCRIPTION
## 📋 작업 내용
> ``global`` 패키지 내부 유틸리티 클래스,애플리케이션 전역예외처리,``GenericMapper`` 인터페이스,AWS S3와 관련한 처리를 수행하는 인터페이스와 클래스에 JavaDoc 주석을 추가하였습니다

## 🤝 리뷰 시 참고사항
> ``global.therdparty`` 패키지 내부 이메일 관련 클래스들의 주석추가는 @jihoonwjj 님이 개선사항을 적용하면 진행하도록 하겠습니다

## ✅ 체크리스트
- [x] 이 작업으로 인해 변경이 필요한 문서를 작성 또는 수정했나요? (e.g. `README`, `.env.example`)
- [x] 작업한 코드가 정상적으로 동작하는지 확인했나요?
- [x] 작업한 코드에 대한 테스트 코드를 작성하거나 수정했나요?
- [x] Merge 대상 브랜치를 올바르게 설정했나요?
- [x] 해당 PR과 관련 없는 작업이 포함되지는 않았나요?
- [x] PR의 올바른 라벨과 리뷰어를 설정했나요?