### PR TITLE
``MemberWebAdapter`` 메서드별 반환 자료형 강제

### DIFF
--- a/src/main/java/team/incude/gsmc/v2/domain/auth/application/port/AuthApplicationPort.java
+++ b/src/main/java/team/incude/gsmc/v2/domain/auth/application/port/AuthApplicationPort.java
@@ -2,6 +2,22 @@ package team.incude.gsmc.v2.domain.auth.application.port;
 
 import team.incude.gsmc.v2.domain.auth.presentation.data.response.AuthTokenResponse;
 
+/**
+ * 인증(Auth) 관련 유스케이스를 정의하는 애플리케이션 포트 인터페이스입니다.
+ * <p>회원 가입, 로그인, 토큰 갱신, 이메일 인증, 비밀번호 변경 등 인증 및 사용자 초기화 관련 기능을 제공합니다.
+ * 이 포트는 Web 계층에서 도메인 계층으로 진입하는 진입점 역할을 하며,
+ * {@code @Port(direction = PortDirection.INBOUND)}로 선언되는 것이 일반적입니다.
+ * 주요 기능:
+ * <ul>
+ *   <li>{@code signUp} - 회원 가입</li>
+ *   <li>{@code signIn} - 로그인</li>
+ *   <li>{@code refresh} - 액세스 토큰 갱신</li>
+ *   <li>{@code verifyEmail} - 이메일 인증 코드 검증</li>
+ *   <li>{@code sendAuthenticationEmail} - 인증 이메일 발송</li>
+ *   <li>{@code changePassword} - 비밀번호 변경</li>
+ * </ul>
+ * @author jihoonwjj
+ */
 public interface AuthApplicationPort {
     void signUp(String name, String email, String password);
 

--- a/src/main/java/team/incude/gsmc/v2/domain/member/application/MemberApplicationAdapter.java
+++ b/src/main/java/team/incude/gsmc/v2/domain/member/application/MemberApplicationAdapter.java
@@ -13,6 +13,19 @@ import team.incude.gsmc.v2.global.annotation.adapter.Adapter;
 
 import java.util.List;
 
+/**
+ * 사용자 관련 유스케이스의 진입점을 정의하는 애플리케이션 어댑터 클래스입니다.
+ * <p>{@link MemberApplicationPort}를 구현하며, Web 계층의 요청을 실제 유스케이스 실행으로 위임합니다.
+ * 내부적으로 네 가지 주요 유스케이스를 조합하여 사용자 조회 관련 기능을 제공합니다.
+ * <ul>
+ *   <li>{@link FindAllStudentUseCase} - 전체 학생 목록 조회</li>
+ *   <li>{@link SearchStudentUseCase} - 이름/학년/반 조건 기반 검색</li>
+ *   <li>{@link FindCurrentStudentUseCase} - 현재 로그인한 사용자 정보 조회</li>
+ *   <li>{@link FindStudentByStudentCodeUseCase} - 학생 코드 기반 단일 조회</li>
+ * </ul>
+ * 이 클래스는 어댑터 계층에서 도메인 계층으로의 연결을 담당하는 구조적 진입점입니다.
+ * @author snowykte0426
+ */
 @Adapter(direction = PortDirection.INBOUND)
 @RequiredArgsConstructor
 public class MemberApplicationAdapter implements MemberApplicationPort {

--- a/src/main/java/team/incude/gsmc/v2/domain/member/application/port/MemberApplicationPort.java
+++ b/src/main/java/team/incude/gsmc/v2/domain/member/application/port/MemberApplicationPort.java
@@ -7,6 +7,19 @@ import team.incude.gsmc.v2.global.annotation.port.Port;
 
 import java.util.List;
 
+/**
+ * Member 도메인의 주요 유스케이스를 정의하는 애플리케이션 포트 인터페이스입니다.
+ * <p>학생 목록 조회, 검색, 현재 로그인한 학생 조회, 특정 학생 코드 기반 조회 등의 기능을 정의하며,
+ * Web 어댑터 계층이 이 포트를 통해 도메인 로직에 접근합니다.
+ * <p>{@code @Port(direction = PortDirection.INBOUND)}로 선언되어 외부 요청이 도메인 계층으로 유입되는 진입점 역할을 합니다.
+ * <ul>
+ *   <li>{@code findAllStudents()} - 전체 학생 목록 조회</li>
+ *   <li>{@code searchStudents(...)} - 이름/학년/반 조건으로 학생 검색</li>
+ *   <li>{@code findCurrentStudent()} - 현재 로그인한 사용자 정보 조회</li>
+ *   <li>{@code findMemberByStudentCode(...)} - 학생 코드 기반 조회</li>
+ * </ul>
+ * @author snowykte0426
+ */
 @Port(direction = PortDirection.INBOUND)
 public interface MemberApplicationPort {
     List<GetStudentResponse> findAllStudents();

--- a/src/main/java/team/incude/gsmc/v2/domain/member/application/port/MemberPersistencePort.java
+++ b/src/main/java/team/incude/gsmc/v2/domain/member/application/port/MemberPersistencePort.java
@@ -4,6 +4,21 @@ import team.incude.gsmc.v2.domain.member.domain.Member;
 import team.incude.gsmc.v2.global.annotation.PortDirection;
 import team.incude.gsmc.v2.global.annotation.port.Port;
 
+/**
+ * 사용자(Member) 도메인의 영속성 계층과 통신하는 포트 인터페이스입니다.
+ * <p>이 인터페이스는 회원 정보를 조회, 저장, 수정하는 기능을 추상화하며,
+ * 도메인 계층이 데이터베이스 세부 구현에 의존하지 않도록 분리합니다.
+ * <p>{@code @Port(direction = PortDirection.OUTBOUND)}로 지정되어 외부 시스템(SPI)으로의 호출을 의미합니다.
+ * <p>주요 기능:
+ * <ul>
+ *   <li>{@code existsMemberByEmail} - 이메일 존재 여부 확인</li>
+ *   <li>{@code saveMember} - 회원 저장</li>
+ *   <li>{@code findMemberByEmail} - 이메일로 회원 조회</li>
+ *   <li>{@code findMemberByStudentDetailStudentCode} - 학생 코드로 회원 조회</li>
+ *   <li>{@code updateMemberPassword} - 비밀번호 수정</li>
+ * </ul>
+ * @author snowykte0426, jihoonwjj
+ */
 @Port(direction = PortDirection.OUTBOUND)
 public interface MemberPersistencePort {
     Boolean existsMemberByEmail(String email);

--- a/src/main/java/team/incude/gsmc/v2/domain/member/application/port/StudentDetailPersistencePort.java
+++ b/src/main/java/team/incude/gsmc/v2/domain/member/application/port/StudentDetailPersistencePort.java
@@ -9,6 +9,23 @@ import team.incude.gsmc.v2.global.annotation.port.Port;
 
 import java.util.List;
 
+/**
+ * 학생 상세 정보(StudentDetail)의 영속성 계층과 통신하는 포트 인터페이스입니다.
+ * <p>학생 정보 및 증빙 정보를 기반으로 한 복합 조회, 점수 집계, 저장 등의 기능을 제공합니다.
+ * 이 포트는 도메인 계층이 데이터 저장소에 직접 의존하지 않도록 분리하기 위해 사용됩니다.
+ * <p>{@code @Port(direction = PortDirection.OUTBOUND)}로 선언되며,
+ * 실제 구현은 JPA, QueryDSL, 외부 API 연동 등 다양한 방식으로 확장될 수 있습니다.
+ * 주요 기능:
+ * <ul>
+ *   <li>학생 코드 또는 이메일 기반 조회 (락 포함)</li>
+ *   <li>학년/반 조건 기반 목록 조회</li>
+ *   <li>증빙자료 포함 조회</li>
+ *   <li>검토 상태 존재 여부 기반 목록 필터링</li>
+ *   <li>검색 조건 및 페이징 처리된 학생 조회</li>
+ *   <li>총합 점수 조회 및 저장</li>
+ * </ul>
+ * @author snowykte0426
+ */
 @Port(direction = PortDirection.OUTBOUND)
 public interface StudentDetailPersistencePort {
     StudentDetail findStudentDetailByStudentCode(String studentCode);
@@ -25,7 +42,7 @@ public interface StudentDetailPersistencePort {
 
     List<StudentDetailWithEvidence> findStudentDetailWithEvidenceReviewStatusNotNullMember();
 
-    Page<StudentDetailWithEvidence> searchStudentDetailWithEvidenceReiewStatusNotNullMember(String name, Integer grade, Integer classNumber, Pageable pageable);
+    Page<StudentDetailWithEvidence> searchStudentDetailWithEvidenceReviewStatusNotNullMember(String name, Integer grade, Integer classNumber, Pageable pageable);
 
     Integer findTotalScoreByStudentCode(String studentCode);
 

--- a/src/main/java/team/incude/gsmc/v2/domain/member/application/usecase/FindAllStudentUseCase.java
+++ b/src/main/java/team/incude/gsmc/v2/domain/member/application/usecase/FindAllStudentUseCase.java
@@ -4,6 +4,12 @@ import team.incude.gsmc.v2.domain.member.presentation.data.response.GetStudentRe
 
 import java.util.List;
 
+/**
+ * 전체 학생 목록을 조회하는 유스케이스를 정의하는 인터페이스입니다.
+ * <p>현재 시스템에 등록된 모든 학생 정보를 조회하여 {@link GetStudentResponse} 리스트로 반환합니다.
+ * 어드민 또는 관리자 화면에서 전체 학생을 표시할 때 사용됩니다.
+ * @author snowykte0426
+ */
 public interface FindAllStudentUseCase {
     List<GetStudentResponse> execute();
 }

--- a/src/main/java/team/incude/gsmc/v2/domain/member/application/usecase/FindCurrentStudentUseCase.java
+++ b/src/main/java/team/incude/gsmc/v2/domain/member/application/usecase/FindCurrentStudentUseCase.java
@@ -2,6 +2,13 @@ package team.incude.gsmc.v2.domain.member.application.usecase;
 
 import team.incude.gsmc.v2.domain.member.presentation.data.response.GetStudentResponse;
 
+/**
+ * 현재 로그인한 학생 정보를 조회하는 유스케이스를 정의하는 인터페이스입니다.
+ * <p>인증 정보를 기반으로 현재 사용자의 이메일 또는 세션을 확인하고,
+ * 해당 사용자에 대한 상세 학생 정보를 {@link GetStudentResponse} 형태로 반환합니다.
+ * 이 유스케이스는 로그인된 학생의 개인정보와 점수 상태 등을 클라이언트에 제공하기 위해 사용됩니다.
+ * @author snowykte0426
+ */
 public interface FindCurrentStudentUseCase {
     GetStudentResponse execute();
 }

--- a/src/main/java/team/incude/gsmc/v2/domain/member/application/usecase/FindStudentByStudentCodeUseCase.java
+++ b/src/main/java/team/incude/gsmc/v2/domain/member/application/usecase/FindStudentByStudentCodeUseCase.java
@@ -2,6 +2,15 @@ package team.incude.gsmc.v2.domain.member.application.usecase;
 
 import team.incude.gsmc.v2.domain.member.presentation.data.response.GetStudentResponse;
 
+/**
+ * 학생 코드로 학생 정보를 조회하는 유스케이스를 정의하는 인터페이스입니다.
+ * <p>학생 고유 코드({@code studentCode})를 기반으로 {@link GetStudentResponse} 형태의 학생 정보를 반환합니다.
+ * 주로 어드민 또는 외부 시스템이 특정 학생의 상세 정보를 조회할 때 사용됩니다.
+ * @see team.incude.gsmc.v2.domain.member.application.usecase.service.FindStudentByStudentCodeService
+ * @see team.incude.gsmc.v2.domain.member.presentation.MemberWebAdapter
+ * @see GetStudentResponse
+ * @author snowykte0426
+ */
 public interface FindStudentByStudentCodeUseCase {
     GetStudentResponse execute(String studentCode);
 }

--- a/src/main/java/team/incude/gsmc/v2/domain/member/application/usecase/SearchStudentUseCase.java
+++ b/src/main/java/team/incude/gsmc/v2/domain/member/application/usecase/SearchStudentUseCase.java
@@ -2,6 +2,14 @@ package team.incude.gsmc.v2.domain.member.application.usecase;
 
 import team.incude.gsmc.v2.domain.member.presentation.data.response.SearchStudentResponse;
 
+/**
+ * 조건 기반 학생 검색 유스케이스를 정의하는 인터페이스입니다.
+ * <p>학생의 이름, 학년, 반 번호를 기준으로 페이징 처리된 학생 목록을 조회합니다.
+ * 이 유스케이스는 클라이언트가 검색 필터를 통해 학생을 조회할 수 있도록 지원합니다.
+ * @see team.incude.gsmc.v2.domain.member.presentation.data.response.SearchStudentResponse
+ * @see team.incude.gsmc.v2.domain.member.application.usecase.service.SearchStudentService
+ * @author snowykte0426
+ */
 public interface SearchStudentUseCase {
     SearchStudentResponse execute(String name, Integer grade, Integer classNumber, Integer page, Integer size);
 }

--- a/src/main/java/team/incude/gsmc/v2/domain/member/application/usecase/service/FindAllStudentService.java
+++ b/src/main/java/team/incude/gsmc/v2/domain/member/application/usecase/service/FindAllStudentService.java
@@ -8,6 +8,13 @@ import team.incude.gsmc.v2.domain.member.presentation.data.response.GetStudentRe
 
 import java.util.List;
 
+/**
+ * 전체 학생 목록을 조회하는 유스케이스 구현 클래스입니다.
+ * <p>{@link FindAllStudentUseCase}를 구현하며, 학생 정보를 조회하는 기능을 제공합니다.
+ * <p>{@link StudentDetailPersistencePort}를 통해 영속성 계층에서 학생 정보를 조회하고,
+ * {@link GetStudentResponse}로 매핑하여 클라이언트에 전달할 수 있는 형태로 반환합니다.
+ * @author snowykte0426
+ */
 @Service
 @RequiredArgsConstructor
 public class FindAllStudentService implements FindAllStudentUseCase {

--- a/src/main/java/team/incude/gsmc/v2/domain/member/application/usecase/service/FindCurrentStudentService.java
+++ b/src/main/java/team/incude/gsmc/v2/domain/member/application/usecase/service/FindCurrentStudentService.java
@@ -8,9 +8,17 @@ import team.incude.gsmc.v2.domain.member.domain.StudentDetailWithEvidence;
 import team.incude.gsmc.v2.domain.member.presentation.data.response.GetStudentResponse;
 import team.incude.gsmc.v2.global.security.jwt.usecase.service.CurrentMemberProvider;
 
+/**
+ * 현재 로그인한 학생 정보를 조회하는 유스케이스 구현 클래스입니다.
+ * <p>{@link FindCurrentStudentUseCase}를 구현하며, 인증된 사용자의 이메일을 기준으로 학생 상세 정보와 증빙자료 상태를 함께 조회합니다.
+ * <p>반환되는 정보는 {@link GetStudentResponse}에 담겨 클라이언트에 전달됩니다.
+ * <p>이 서비스는 {@link CurrentMemberProvider}를 통해 로그인된 사용자 정보를 획득하고,
+ * {@link StudentDetailPersistencePort}를 통해 학생 정보를 영속성 계층에서 조회합니다.
+ * @author snowykte0426
+ */
 @Service
 @RequiredArgsConstructor
-public class FindCurrentCurrentStudentService implements FindCurrentStudentUseCase {
+public class FindCurrentStudentService implements FindCurrentStudentUseCase {
 
     private final StudentDetailPersistencePort studentDetailPersistencePort;
     private final CurrentMemberProvider currentMemberProvider;

--- a/src/main/java/team/incude/gsmc/v2/domain/member/application/usecase/service/FindStudentByStudentCodeService.java
+++ b/src/main/java/team/incude/gsmc/v2/domain/member/application/usecase/service/FindStudentByStudentCodeService.java
@@ -7,6 +7,12 @@ import team.incude.gsmc.v2.domain.member.application.usecase.FindStudentByStuden
 import team.incude.gsmc.v2.domain.member.domain.StudentDetailWithEvidence;
 import team.incude.gsmc.v2.domain.member.presentation.data.response.GetStudentResponse;
 
+/**
+ * 학생 코드 기반으로 학생 정보를 조회하는 유스케이스 구현 클래스입니다.
+ * <p>{@link FindStudentByStudentCodeUseCase}를 구현하며, 주어진 학생 코드에 해당하는 학생 정보를 조회하여 {@link GetStudentResponse}로 반환합니다.
+ * <p>{@link StudentDetailPersistencePort}를 통해 학생 상세 정보와 증빙 상태를 함께 조회합니다.
+ * @author snowykte0426
+ */
 @Service
 @RequiredArgsConstructor
 public class FindStudentByStudentCodeService implements FindStudentByStudentCodeUseCase {

--- a/src/main/java/team/incude/gsmc/v2/domain/member/application/usecase/service/SearchStudentService.java
+++ b/src/main/java/team/incude/gsmc/v2/domain/member/application/usecase/service/SearchStudentService.java
@@ -10,6 +10,14 @@ import team.incude.gsmc.v2.domain.member.domain.StudentDetailWithEvidence;
 import team.incude.gsmc.v2.domain.member.presentation.data.response.GetStudentResponse;
 import team.incude.gsmc.v2.domain.member.presentation.data.response.SearchStudentResponse;
 
+/**
+ * 학생 조건 검색 유스케이스의 구현 클래스입니다.
+ * <p>{@link SearchStudentUseCase}를 구현하며, 이름, 학년, 반 번호를 기준으로 필터링된 학생 목록을 페이징 처리하여 조회합니다.
+ * <p>{@link StudentDetailPersistencePort}를 통해 영속성 계층에서 검색 쿼리를 수행하고,
+ * 결과는 {@link SearchStudentResponse}로 매핑되어 클라이언트에 전달됩니다.
+ * <p>검색 결과에는 학생의 점수, 증빙자료 상태, 권한 정보 등이 포함됩니다.
+ * @author snowykte0426
+ */
 @Service
 @RequiredArgsConstructor
 public class SearchStudentService implements SearchStudentUseCase {
@@ -18,7 +26,7 @@ public class SearchStudentService implements SearchStudentUseCase {
 
     @Override
     public SearchStudentResponse execute(String name, Integer grade, Integer classNumber, Integer page, Integer size) {
-        Page<StudentDetailWithEvidence> studentDetails = studentDetailPersistencePort.searchStudentDetailWithEvidenceReiewStatusNotNullMember(name, grade, classNumber, Pageable.ofSize(size));
+        Page<StudentDetailWithEvidence> studentDetails = studentDetailPersistencePort.searchStudentDetailWithEvidenceReviewStatusNotNullMember(name, grade, classNumber, Pageable.ofSize(size));
         return new SearchStudentResponse(
                 studentDetails.getTotalPages(),
                 studentDetails.getTotalElements(),

--- a/src/main/java/team/incude/gsmc/v2/domain/member/exception/MemberInvalidException.java
+++ b/src/main/java/team/incude/gsmc/v2/domain/member/exception/MemberInvalidException.java
@@ -3,6 +3,13 @@ package team.incude.gsmc.v2.domain.member.exception;
 import team.incude.gsmc.v2.global.error.ErrorCode;
 import team.incude.gsmc.v2.global.error.exception.GsmcException;
 
+/**
+ * 유효하지 않은 학생-사용자 연관 관계가 감지되었을 때 발생하는 예외입니다.
+ * <p>예를 들어 학생 상세 정보가 존재하지만, 이에 연결된 사용자 정보가 없거나 불일치하는 경우 발생합니다.
+ * {@link ErrorCode#STUDENT_MEMBER_INVALID}에 매핑되어 클라이언트에 적절한 오류 메시지를 전달합니다.
+ * <p>주로 {@code StudentDetailPersistencePort} 또는 {@code MemberPersistencePort}에서 연관된 회원 조회 실패 시 사용됩니다.
+ * @author jihoonwjj
+ */
 public class MemberInvalidException extends GsmcException {
     public MemberInvalidException() {
         super(ErrorCode.STUDENT_MEMBER_INVALID);

--- a/src/main/java/team/incude/gsmc/v2/domain/member/exception/MemberNotFoundException.java
+++ b/src/main/java/team/incude/gsmc/v2/domain/member/exception/MemberNotFoundException.java
@@ -3,6 +3,13 @@ package team.incude.gsmc.v2.domain.member.exception;
 import team.incude.gsmc.v2.global.error.ErrorCode;
 import team.incude.gsmc.v2.global.error.exception.GsmcException;
 
+/**
+ * 사용자(Member) 정보를 찾을 수 없을 때 발생하는 예외입니다.
+ * <p>이메일, 학생 코드 등으로 사용자 조회 시 해당 정보가 존재하지 않을 경우 발생하며,
+ * {@link ErrorCode#MEMBER_NOT_FOUND}에 매핑되어 클라이언트에 적절한 오류 메시지를 전달합니다.
+ * <p>주로 {@code MemberPersistencePort} 또는 {@code StudentDetailPersistencePort}에서 조회 실패 시 사용됩니다.
+ * @author snowykte0426
+ */
 public class MemberNotFoundException extends GsmcException {
     public MemberNotFoundException() {
         super(ErrorCode.MEMBER_NOT_FOUND);

--- a/src/main/java/team/incude/gsmc/v2/domain/member/persistence/MemberPersistenceAdapter.java
+++ b/src/main/java/team/incude/gsmc/v2/domain/member/persistence/MemberPersistenceAdapter.java
@@ -15,6 +15,19 @@ import java.util.Optional;
 import static team.incude.gsmc.v2.domain.member.persistence.entity.QMemberJpaEntity.memberJpaEntity;
 import static team.incude.gsmc.v2.domain.member.persistence.entity.QStudentDetailJpaEntity.studentDetailJpaEntity;
 
+/**
+ * 사용자(Member) 도메인의 영속성 어댑터 구현체입니다.
+ * <p>{@link MemberPersistencePort}를 구현하며, JPA 및 QueryDSL을 통해 사용자 정보를 조회, 저장, 수정합니다.
+ * <p>{@link MemberMapper}를 통해 도메인 객체와 엔티티 간 변환을 수행합니다.
+ * 주요 기능:
+ * <ul>
+ *   <li>이메일 또는 학생 코드로 사용자 조회</li>
+ *   <li>사용자 존재 여부 확인</li>
+ *   <li>사용자 저장</li>
+ *   <li>비밀번호 업데이트</li>
+ * </ul>
+ * @author snowykte0426, jihoonwjj
+ */
 @Adapter(direction = PortDirection.OUTBOUND)
 @RequiredArgsConstructor
 public class MemberPersistenceAdapter implements MemberPersistencePort {
@@ -23,6 +36,12 @@ public class MemberPersistenceAdapter implements MemberPersistencePort {
     private final JPAQueryFactory jpaQueryFactory;
     private final MemberMapper memberMapper;
 
+    /**
+     * 이메일을 기준으로 사용자 정보를 조회합니다.
+     * @param email 사용자 이메일
+     * @return 도메인 사용자 객체
+     * @throws MemberNotFoundException 사용자를 찾을 수 없는 경우
+     */
     @Override
     public Member findMemberByEmail(String email) {
         return Optional.ofNullable(
@@ -33,6 +52,12 @@ public class MemberPersistenceAdapter implements MemberPersistencePort {
         ).map(memberMapper::toDomain).orElseThrow(MemberNotFoundException::new);
     }
 
+    /**
+     * 학생 코드에 해당하는 학생의 사용자 정보를 조회합니다.
+     * @param studentCode 학생 고유 코드
+     * @return 도메인 회원 객체
+     * @throws MemberNotFoundException 사용자를 찾을 수 없는 경우
+     */
     @Override
     public Member findMemberByStudentDetailStudentCode(String studentCode) {
         return Optional.ofNullable(
@@ -44,6 +69,11 @@ public class MemberPersistenceAdapter implements MemberPersistencePort {
         ).map(memberMapper::toDomain).orElseThrow(MemberNotFoundException::new);
     }
 
+    /**
+     * 주어진 이메일을 가진 사용자가 존재하는지 확인합니다.
+     * @param email 사용자 이메일
+     * @return 존재 여부
+     */
     @Override
     public Boolean existsMemberByEmail(String email) {
         var result = jpaQueryFactory
@@ -54,11 +84,21 @@ public class MemberPersistenceAdapter implements MemberPersistencePort {
         return result != null;
     }
 
+    /**
+     * 사용자 정보를 저장합니다.
+     * @param member 저장할 사용자 도메인 객체
+     * @return 저장된 사용자 도메인 객체
+     */
     @Override
     public Member saveMember(Member member) {
         return memberMapper.toDomain(memberJpaRepository.save(memberMapper.toEntity(member)));
     }
 
+    /**
+     * 사용자의 비밀번호를 갱신합니다.
+     * @param memberId 사용자 ID
+     * @param newPassword 새 비밀번호
+     */
     @Override
     public void updateMemberPassword(Long memberId, String newPassword) {
         jpaQueryFactory

--- a/src/main/java/team/incude/gsmc/v2/domain/member/persistence/StudentDetailPersistenceAdapter.java
+++ b/src/main/java/team/incude/gsmc/v2/domain/member/persistence/StudentDetailPersistenceAdapter.java
@@ -25,6 +25,21 @@ import java.util.Optional;
 import static team.incude.gsmc.v2.domain.evidence.persistence.entity.QEvidenceJpaEntity.evidenceJpaEntity;
 import static team.incude.gsmc.v2.domain.member.persistence.entity.QStudentDetailJpaEntity.studentDetailJpaEntity;
 
+/**
+ * 학생 상세 정보에 대한 영속성 접근을 제공하는 Adapter 클래스입니다.
+ * <p>{@link StudentDetailPersistencePort}를 구현하며, QueryDSL과 JPA를 통해 학생 정보 및 증빙 상태를 조회, 저장합니다.
+ * {@link StudentDetailMapper}를 통해 도메인 객체와 엔티티 간 매핑을 수행합니다.
+ * <p>제공 기능:
+ * <ul>
+ *   <li>학생 코드 또는 이메일 기반 단건 조회</li>
+ *   <li>락을 포함한 조회</li>
+ *   <li>학급별 조회</li>
+ *   <li>증빙자료 포함 학생 조회</li>
+ *   <li>검색 조건 기반 페이징</li>
+ *   <li>총점 조회 및 저장</li>
+ * </ul>
+ * @author snowykte0426
+ */
 @Adapter(direction = PortDirection.OUTBOUND)
 @RequiredArgsConstructor
 public class StudentDetailPersistenceAdapter implements StudentDetailPersistencePort {
@@ -33,6 +48,12 @@ public class StudentDetailPersistenceAdapter implements StudentDetailPersistence
     private final StudentDetailMapper studentDetailMapper;
     private final JPAQueryFactory jpaQueryFactory;
 
+    /**
+     * 학생 코드를 기준으로 학생 상세 정보를 조회합니다.
+     * @param studentCode 학생 고유 코드
+     * @return 학생 상세 도메인 객체
+     * @throws MemberInvalidException 학생이 존재하지 않을 경우
+     */
     @Override
     public StudentDetail findStudentDetailByStudentCode(String studentCode) {
         return Optional.ofNullable(
@@ -43,6 +64,12 @@ public class StudentDetailPersistenceAdapter implements StudentDetailPersistence
         ).map(studentDetailMapper::toDomain).orElseThrow(MemberInvalidException::new);
     }
 
+    /**
+     * 학생 코드를 기준으로 비관적 락을 걸고 학생 정보를 조회합니다.
+     * @param studentCode 학생 고유 코드
+     * @return 락이 걸린 학생 상세 도메인 객체
+     * @throws MemberInvalidException 학생이 존재하지 않을 경우
+     */
     @Override
     public StudentDetail findStudentDetailByStudentCodeWithLock(String studentCode) {
         return Optional.ofNullable(
@@ -54,6 +81,12 @@ public class StudentDetailPersistenceAdapter implements StudentDetailPersistence
         ).map(studentDetailMapper::toDomain).orElseThrow(MemberInvalidException::new);
     }
 
+    /**
+     * 이메일을 기준으로 학생 상세 정보를 조회합니다.
+     * @param email 회원 이메일
+     * @return 학생 상세 도메인 객체
+     * @throws MemberInvalidException 학생이 존재하지 않을 경우
+     */
     @Override
     public StudentDetail findStudentDetailByMemberEmail(String email) {
         return Optional.ofNullable(
@@ -66,6 +99,12 @@ public class StudentDetailPersistenceAdapter implements StudentDetailPersistence
         ).map(studentDetailMapper::toDomain).orElseThrow(MemberInvalidException::new);
     }
 
+    /**
+     * 주어진 학년과 반 번호에 해당하는 학생 목록을 조회합니다.
+     * @param grade 학년
+     * @param classNumber 반 번호
+     * @return 학생 상세 도메인 객체 리스트
+     */
     @Override
     public List<StudentDetail> findStudentDetailByGradeAndClassNumber(Integer grade, Integer classNumber) {
         return jpaQueryFactory
@@ -78,6 +117,12 @@ public class StudentDetailPersistenceAdapter implements StudentDetailPersistence
                 .toList();
     }
 
+    /**
+     * 학생 코드를 기준으로 증빙 포함 학생 정보를 조회합니다.
+     * @param studentCode 학생 고유 코드
+     * @return 증빙 포함 학생 상세 정보
+     * @throws MemberNotFoundException 학생이 존재하지 않을 경우
+     */
     @Override
     public StudentDetailWithEvidence findStudentDetailWithEvidenceByStudentCode(String studentCode) {
         return Optional.ofNullable(
@@ -103,6 +148,12 @@ public class StudentDetailPersistenceAdapter implements StudentDetailPersistence
         ).map(studentDetailMapper::fromProjection).orElseThrow(MemberNotFoundException::new);
     }
 
+    /**
+     * 이메일을 기준으로 증빙자료 포함 학생 정보를 조회합니다.
+     * @param email 회원 이메일
+     * @return 증빙 포함 학생 상세 정보
+     * @throws MemberNotFoundException 학생이 존재하지 않을 경우
+     */
     @Override
     public StudentDetailWithEvidence findStudentDetailWithEvidenceByMemberEmail(String email) {
         return Optional.ofNullable(
@@ -128,6 +179,10 @@ public class StudentDetailPersistenceAdapter implements StudentDetailPersistence
         ).map(studentDetailMapper::fromProjection).orElseThrow(MemberNotFoundException::new);
     }
 
+    /**
+     * 증빙자료 검토 상태가 존재하는 사용자 정보를 가진 학생 목록을 조회합니다.
+     * @return 증빙 포함 학생 상세 정보 리스트
+     */
     @Override
     public List<StudentDetailWithEvidence> findStudentDetailWithEvidenceReviewStatusNotNullMember() {
         return jpaQueryFactory
@@ -158,8 +213,16 @@ public class StudentDetailPersistenceAdapter implements StudentDetailPersistence
                 .toList();
     }
 
+    /**
+     * 검토 상태가 존재하는 학생 중 검색 조건에 부합하는 목록을 페이징하여 조회합니다.
+     * @param name 학생 이름 필터
+     * @param grade 학년 필터
+     * @param classNumber 반 번호 필터
+     * @param pageable 페이징 정보
+     * @return 페이징된 학생 상세 정보 목록
+     */
     @Override
-    public Page<StudentDetailWithEvidence> searchStudentDetailWithEvidenceReiewStatusNotNullMember(String name, Integer grade, Integer classNumber, Pageable pageable) {
+    public Page<StudentDetailWithEvidence> searchStudentDetailWithEvidenceReviewStatusNotNullMember(String name, Integer grade, Integer classNumber, Pageable pageable) {
         List<StudentProjection> content = jpaQueryFactory
                 .select(
                         Projections.constructor(
@@ -211,6 +274,12 @@ public class StudentDetailPersistenceAdapter implements StudentDetailPersistence
         return new PageImpl<>(result, pageable, total != null ? total : 0);
     }
 
+    /**
+     * 학생 코드로 총합 점수를 조회합니다.
+     * @param studentCode 학생 고유 코드
+     * @return 총합 점수
+     * @throws MemberInvalidException 학생이 존재하지 않을 경우
+     */
     @Override
     public Integer findTotalScoreByStudentCode(String studentCode) {
         return Optional.ofNullable(
@@ -222,6 +291,11 @@ public class StudentDetailPersistenceAdapter implements StudentDetailPersistence
         ).orElseThrow(MemberInvalidException::new);
     }
 
+    /**
+     * 학생 상세 도메인 객체를 저장합니다.
+     * @param studentDetail 저장할 도메인 객체
+     * @return 저장된 학생 상세 도메인 객체
+     */
     @Override
     public StudentDetail saveStudentDetail(StudentDetail studentDetail) {
         return studentDetailMapper.toDomain(studentDetailJpaRepository.save(studentDetailMapper.toEntity(studentDetail)));

--- a/src/main/java/team/incude/gsmc/v2/domain/member/persistence/mapper/HomeroomTeacherDetailMapper.java
+++ b/src/main/java/team/incude/gsmc/v2/domain/member/persistence/mapper/HomeroomTeacherDetailMapper.java
@@ -6,12 +6,29 @@ import team.incude.gsmc.v2.domain.member.domain.HomeroomTeacherDetail;
 import team.incude.gsmc.v2.domain.member.persistence.entity.HomeroomTeacherDetailJpaEntity;
 import team.incude.gsmc.v2.global.mapper.GenericMapper;
 
+/**
+ * {@link HomeroomTeacherDetail} 도메인 객체와 {@link HomeroomTeacherDetailJpaEntity} JPA 엔티티 간의 매핑을 담당하는 클래스입니다.
+ * <p>{@link GenericMapper}를 구현하며, 담임 교사 상세 정보의 저장/조회 시 객체 간 변환을 일관되게 수행합니다.
+ * 내부적으로 {@link MemberMapper}를 활용하여 연관된 교사(Member) 정보도 함께 매핑합니다.
+ * 주요 역할:
+ * <ul>
+ *   <li>도메인 객체를 JPA 엔티티로 변환하여 저장 가능하도록 구성</li>
+ *   <li>JPA 엔티티를 도메인 객체로 변환하여 도메인 계층에서 활용</li>
+ * </ul>
+ * 이 매퍼는 영속계층 어댑터에서 사용됩니다.
+ * @author snowykte0426, jihoonwjj
+ */
 @Component
 @RequiredArgsConstructor
 public class HomeroomTeacherDetailMapper implements GenericMapper<HomeroomTeacherDetailJpaEntity, HomeroomTeacherDetail> {
 
     private final MemberMapper memberMapper;
 
+    /**
+     * {@link HomeroomTeacherDetail} 객체를 {@link HomeroomTeacherDetailJpaEntity}로 변환합니다.
+     * @param homeroomTeacherDetail 변환할 도메인 객체
+     * @return 변환된 JPA 엔티티
+     */
     @Override
     public HomeroomTeacherDetailJpaEntity toEntity(HomeroomTeacherDetail homeroomTeacherDetail) {
         return HomeroomTeacherDetailJpaEntity.builder()
@@ -26,6 +43,11 @@ public class HomeroomTeacherDetailMapper implements GenericMapper<HomeroomTeache
                 .build();
     }
 
+    /**
+     * {@link HomeroomTeacherDetailJpaEntity}를 {@link HomeroomTeacherDetail} 객체로 변환합니다.
+     * @param homeroomTeacherDetailJpaEntity 변환할 JPA 엔티티
+     * @return 변환된 도메인 객체
+     */
     @Override
     public HomeroomTeacherDetail toDomain(HomeroomTeacherDetailJpaEntity homeroomTeacherDetailJpaEntity) {
         return HomeroomTeacherDetail.builder()

--- a/src/main/java/team/incude/gsmc/v2/domain/member/persistence/mapper/MemberMapper.java
+++ b/src/main/java/team/incude/gsmc/v2/domain/member/persistence/mapper/MemberMapper.java
@@ -5,9 +5,24 @@ import team.incude.gsmc.v2.domain.member.domain.Member;
 import team.incude.gsmc.v2.domain.member.persistence.entity.MemberJpaEntity;
 import team.incude.gsmc.v2.global.mapper.GenericMapper;
 
+/**
+ * 도메인 {@link Member} 객체와 JPA 엔티티 {@link MemberJpaEntity} 간의 매핑을 담당하는 클래스입니다.
+ * <p>{@link GenericMapper}를 구현하여 도메인 계층과 영속성 계층 간의 의존성을 분리하고, 일관된 변환 로직을 제공합니다.
+ * <ul>
+ *   <li>{@code toEntity} - 도메인 객체를 엔티티로 변환</li>
+ *   <li>{@code toDomain} - 엔티티를 도메인 객체로 변환</li>
+ * </ul>
+ * 이 매퍼는 주로 영속계층 어댑터에서 사용됩니다.
+ * @author snowykte0426
+ */
 @Component
 public class MemberMapper implements GenericMapper<MemberJpaEntity, Member> {
 
+    /**
+     * {@link Member} 객체를 {@link MemberJpaEntity}로 변환합니다.
+     * @param member 변환할 도메인 객체
+     * @return 변환된 JPA 엔티티
+     */
     @Override
     public MemberJpaEntity toEntity(Member member) {
         return MemberJpaEntity.builder()
@@ -19,6 +34,11 @@ public class MemberMapper implements GenericMapper<MemberJpaEntity, Member> {
                 .build();
     }
 
+    /**
+     * {@link MemberJpaEntity}를 {@link Member} 객체로 변환합니다.
+     * @param memberJpaEntity 변환할 JPA 엔티티
+     * @return 변환된 도메인 객체
+     */
     @Override
     public Member toDomain(MemberJpaEntity memberJpaEntity) {
         return Member.builder()

--- a/src/main/java/team/incude/gsmc/v2/domain/member/persistence/mapper/StudentDetailMapper.java
+++ b/src/main/java/team/incude/gsmc/v2/domain/member/persistence/mapper/StudentDetailMapper.java
@@ -9,12 +9,31 @@ import team.incude.gsmc.v2.domain.member.persistence.entity.StudentDetailJpaEnti
 import team.incude.gsmc.v2.domain.member.persistence.projection.StudentProjection;
 import team.incude.gsmc.v2.global.mapper.GenericMapper;
 
+/**
+ * 도메인 {@link StudentDetail}, {@link StudentDetailWithEvidence} 객체와
+ * JPA 엔티티 {@link StudentDetailJpaEntity}, Projection {@link StudentProjection} 간의 매핑을 담당하는 클래스입니다.
+ * <p>{@link GenericMapper}를 구현하여 도메인 계층과 영속성 계층 간의 의존성을 분리하고,
+ * 일관된 변환 로직을 제공합니다.
+ * <p>지원 기능:
+ * <ul>
+ *   <li>{@code toEntity} - 도메인 {@code StudentDetail} → JPA 엔티티로 변환</li>
+ *   <li>{@code toDomain} - JPA 엔티티 → 도메인 {@code StudentDetail}로 변환</li>
+ *   <li>{@code fromProjection} - Projection 객체 → {@code StudentDetailWithEvidence} 변환</li>
+ * </ul>
+ * 이 매퍼는 영속계층 Adapter 및 Projection 기반 조회 결과 처리에 사용됩니다.
+ * @author snowykte0426, jihoonwjj
+ */
 @Component
 @RequiredArgsConstructor
 public class StudentDetailMapper implements GenericMapper<StudentDetailJpaEntity, StudentDetail> {
 
     private final MemberMapper memberMapper;
 
+    /**
+     * {@link StudentDetail} 객체를 {@link StudentDetailJpaEntity}로 변환합니다.
+     * @param studentDetail 변환할 도메인 객체
+     * @return 변환된 JPA 엔티티
+     */
     @Override
     public StudentDetailJpaEntity toEntity(StudentDetail studentDetail) {
         return StudentDetailJpaEntity.builder()
@@ -32,6 +51,11 @@ public class StudentDetailMapper implements GenericMapper<StudentDetailJpaEntity
                 .build();
     }
 
+    /**
+     * {@link StudentDetailJpaEntity}를 {@link StudentDetail} 객체로 변환합니다.
+     * @param studentDetailJpaEntity 변환할 JPA 엔티티
+     * @return 변환된 도메인 객체
+     */
     @Override
     public StudentDetail toDomain(StudentDetailJpaEntity studentDetailJpaEntity) {
         return StudentDetail.builder()
@@ -49,6 +73,11 @@ public class StudentDetailMapper implements GenericMapper<StudentDetailJpaEntity
                 .build();
     }
 
+    /**
+     * {@link StudentProjection} 객체를 {@link StudentDetailWithEvidence}로 변환합니다.
+     * @param studentProjection 변환할 Projection 객체
+     * @return 변환된 도메인 객체
+     */
     public StudentDetailWithEvidence fromProjection(StudentProjection studentProjection) {
         return StudentDetailWithEvidence.builder()
                 .studentDetail(

--- a/src/main/java/team/incude/gsmc/v2/domain/member/persistence/projection/StudentProjection.java
+++ b/src/main/java/team/incude/gsmc/v2/domain/member/persistence/projection/StudentProjection.java
@@ -2,6 +2,23 @@ package team.incude.gsmc.v2.domain.member.persistence.projection;
 
 import team.incude.gsmc.v2.domain.member.domain.constant.MemberRole;
 
+/**
+ * QueryDSL 또는 Native Query에서 학생 정보를 일부만 조회할 때 사용하는 Projection 클래스입니다.
+ * <p>전체 엔티티가 아닌 필요한 필드만 선별적으로 조회하여 성능을 최적화하고,
+ * {@code StudentDetail} 및 {@code Member}의 결합된 정보를 표현합니다.
+ * <ul>
+ *   <li>{@code email} - 학생 이메일</li>
+ *   <li>{@code name} - 학생 이름</li>
+ *   <li>{@code grade} - 학년</li>
+ *   <li>{@code classNumber} - 반 번호</li>
+ *   <li>{@code number} - 출석 번호</li>
+ *   <li>{@code totalScore} - 총합 점수</li>
+ *   <li>{@code hasPendingEvidence} - 증빙 검토 상태 여부</li>
+ *   <li>{@code role} - 사용자 권한</li>
+ * </ul>
+ * 이 Projection은 주로 학생 목록 조회, 검색 API 등에서 사용됩니다.
+ * @author snowykte0426
+ */
 public record StudentProjection(
         String email,
         String name,

--- a/src/main/java/team/incude/gsmc/v2/domain/member/persistence/repository/MemberJpaRepository.java
+++ b/src/main/java/team/incude/gsmc/v2/domain/member/persistence/repository/MemberJpaRepository.java
@@ -6,7 +6,12 @@ import team.incude.gsmc.v2.domain.member.persistence.entity.MemberJpaEntity;
 
 import java.util.Optional;
 
+/**
+ * 사용자(Member) 엔티티에 대한 Spring Data JPA Repository입니다.
+ * <p>사용자의 기본 CRUD 연산을 제공하며,
+ * JPA의 기본 기능을 상속하여 DB와의 상호작용을 추상화합니다.
+ * @author snowykte0426, jihoonwjj
+ */
 @Repository
 public interface MemberJpaRepository extends JpaRepository<MemberJpaEntity, Long> {
-    Optional<MemberJpaEntity> findByEmail(String email);
 }

--- a/src/main/java/team/incude/gsmc/v2/domain/member/persistence/repository/StudentDetailJpaRepository.java
+++ b/src/main/java/team/incude/gsmc/v2/domain/member/persistence/repository/StudentDetailJpaRepository.java
@@ -4,6 +4,13 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import team.incude.gsmc.v2.domain.member.persistence.entity.StudentDetailJpaEntity;
 
+/**
+ * 학생 상세 정보(StudentDetail) JPA Repository 인터페이스입니다.
+ * <p>{@link StudentDetailJpaEntity}에 대한 기본적인 CRUD 연산을 제공합니다.
+ * Spring Data JPA를 기반으로 하며, 도메인 영속성 계층과 DB 간의 상호작용을 추상화합니다.
+ * <p>복잡한 조건의 쿼리나 커스텀 구현이 필요한 경우 QueryDSL 또는 별도 Repository 커스텀 구현체를 통해 확장할 수 있습니다.
+ * @author jihoonwjj
+ */
 @Repository
 public interface StudentDetailJpaRepository extends JpaRepository<StudentDetailJpaEntity, Long> {
 }

--- a/src/main/java/team/incude/gsmc/v2/domain/member/presentation/MemberWebAdapter.java
+++ b/src/main/java/team/incude/gsmc/v2/domain/member/presentation/MemberWebAdapter.java
@@ -12,10 +12,6 @@ import team.incude.gsmc.v2.domain.member.presentation.data.response.GetStudentRe
 import team.incude.gsmc.v2.domain.member.presentation.data.response.SearchStudentResponse;
 
 import java.util.List;
-import team.incude.gsmc.v2.domain.member.presentation.data.response.GetStudentResponse;
-import team.incude.gsmc.v2.domain.member.presentation.data.response.SearchStudentResponse;
-
-import java.util.List;
 
 /**
  * 사용자 관련 HTTP 요청을 처리하는 Web 어댑터 클래스입니다.

--- a/src/main/java/team/incude/gsmc/v2/domain/member/presentation/MemberWebAdapter.java
+++ b/src/main/java/team/incude/gsmc/v2/domain/member/presentation/MemberWebAdapter.java
@@ -9,6 +9,19 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import team.incude.gsmc.v2.domain.member.application.port.MemberApplicationPort;
 
+/**
+ * 사용자 관련 HTTP 요청을 처리하는 Web 어댑터 클래스입니다.
+ * <p>{@link MemberApplicationPort}를 통해 도메인 계층의 유스케이스를 실행하며,
+ * 학생 목록 조회, 검색, 본인 정보 조회, 특정 학생 정보 조회 등의 기능을 제공합니다.
+ * <p>제공 API:
+ * <ul>
+ *   <li>{@code GET /api/v2/members/students} - 전체 학생 목록 조회</li>
+ *   <li>{@code GET /api/v2/members/students/search} - 학생 조건 검색</li>
+ *   <li>{@code GET /api/v2/members/students/current} - 현재 로그인한 학생 정보 조회</li>
+ *   <li>{@code GET /api/v2/members/students/{studentCode}} - 특정 학생 정보 조회</li>
+ * </ul>
+ * @author snowykte0426
+ */
 @RestController
 @RequestMapping("/api/v2/members")
 @RequiredArgsConstructor

--- a/src/main/java/team/incude/gsmc/v2/domain/member/presentation/MemberWebAdapter.java
+++ b/src/main/java/team/incude/gsmc/v2/domain/member/presentation/MemberWebAdapter.java
@@ -8,6 +8,10 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import team.incude.gsmc.v2.domain.member.application.port.MemberApplicationPort;
+import team.incude.gsmc.v2.domain.member.presentation.data.response.GetStudentResponse;
+import team.incude.gsmc.v2.domain.member.presentation.data.response.SearchStudentResponse;
+
+import java.util.List;
 
 /**
  * 사용자 관련 HTTP 요청을 처리하는 Web 어댑터 클래스입니다.
@@ -30,13 +34,13 @@ public class MemberWebAdapter {
     private final MemberApplicationPort memberApplicationPort;
 
     @GetMapping("/students")
-    public ResponseEntity<Object> getAllStudents() {
+    public ResponseEntity<List<GetStudentResponse>> getAllStudents() {
         return ResponseEntity.status(HttpStatus.OK).body(memberApplicationPort.findAllStudents());
     }
 
     @GetMapping("/students/search")
     @Validated
-    public ResponseEntity<Object> searchStudents(
+    public ResponseEntity<SearchStudentResponse> searchStudents(
             @RequestParam(value = "grade", required = false) Integer grade,
             @RequestParam(value = "classNumber", required = false) Integer classNumber,
             @RequestParam(value = "name", required = false) String name,
@@ -47,12 +51,12 @@ public class MemberWebAdapter {
     }
 
     @GetMapping("/students/current")
-    public ResponseEntity<Object> getCurrentStudent() {
+    public ResponseEntity<GetStudentResponse> getCurrentStudent() {
         return ResponseEntity.status(HttpStatus.OK).body(memberApplicationPort.findCurrentStudent());
     }
 
     @GetMapping("/students/{studentCode}")
-    public ResponseEntity<Object> getStudent(@PathVariable(value = "studentCode") String studentCode) {
+    public ResponseEntity<GetStudentResponse> getStudent(@PathVariable(value = "studentCode") String studentCode) {
         return ResponseEntity.status(HttpStatus.OK).body(memberApplicationPort.findMemberByStudentCode(studentCode));
     }
 }

--- a/src/main/java/team/incude/gsmc/v2/domain/member/presentation/MemberWebAdapter.java
+++ b/src/main/java/team/incude/gsmc/v2/domain/member/presentation/MemberWebAdapter.java
@@ -12,6 +12,10 @@ import team.incude.gsmc.v2.domain.member.presentation.data.response.GetStudentRe
 import team.incude.gsmc.v2.domain.member.presentation.data.response.SearchStudentResponse;
 
 import java.util.List;
+import team.incude.gsmc.v2.domain.member.presentation.data.response.GetStudentResponse;
+import team.incude.gsmc.v2.domain.member.presentation.data.response.SearchStudentResponse;
+
+import java.util.List;
 
 /**
  * 사용자 관련 HTTP 요청을 처리하는 Web 어댑터 클래스입니다.

--- a/src/main/java/team/incude/gsmc/v2/domain/member/presentation/data/response/GetStudentResponse.java
+++ b/src/main/java/team/incude/gsmc/v2/domain/member/presentation/data/response/GetStudentResponse.java
@@ -2,6 +2,24 @@ package team.incude.gsmc.v2.domain.member.presentation.data.response;
 
 import team.incude.gsmc.v2.domain.member.domain.constant.MemberRole;
 
+/**
+ * 학생 정보를 클라이언트에 전달하기 위한 응답 DTO입니다.
+ * <p>학생의 기본 신상 정보(이메일, 이름, 학년/반/번호)와 함께,
+ * 총점, 증빙자료 대기 여부, 권한 정보를 포함하여 반환됩니다.
+ * <ul>
+ *   <li>{@code email} - 학생 이메일</li>
+ *   <li>{@code name} - 학생 이름</li>
+ *   <li>{@code grade} - 학년</li>
+ *   <li>{@code classNumber} - 반 번호</li>
+ *   <li>{@code number} - 출석 번호</li>
+ *   <li>{@code totalScore} - 총합 점수</li>
+ *   <li>{@code hasPendingEvidence} - 증빙 대기 상태 여부</li>
+ *   <li>{@code role} - 사용자의 권한</li>
+ * </ul>
+ * 이 DTO는 주로 {@code /students}, {@code /students/current}, {@code /students/{code}} 등에서 사용됩니다.
+ * @author snowykte0426
+ */
+
 public record GetStudentResponse(
         String email,
         String name,

--- a/src/main/java/team/incude/gsmc/v2/domain/member/presentation/data/response/SearchStudentResponse.java
+++ b/src/main/java/team/incude/gsmc/v2/domain/member/presentation/data/response/SearchStudentResponse.java
@@ -2,6 +2,17 @@ package team.incude.gsmc.v2.domain.member.presentation.data.response;
 
 import java.util.List;
 
+/**
+ * 학생 조건 검색 결과를 담는 응답 DTO입니다.
+ * <p>페이징 처리된 결과로서, 전체 페이지 수와 총 학생 수, 조회된 학생 목록을 포함합니다.
+ * <ul>
+ *   <li>{@code totalPage} - 전체 페이지 수</li>
+ *   <li>{@code totalElements} - 전체 학생 수</li>
+ *   <li>{@code results} - 현재 페이지에 해당하는 학생 목록</li>
+ * </ul>
+ * 이 DTO는 주로 학생 검색 API ({@code /students/search}) 응답으로 사용됩니다.
+ * @author snowykte0426
+ */
 public record SearchStudentResponse(
         Integer totalPage,
         Long totalElements,

--- a/src/main/java/team/incude/gsmc/v2/domain/sheet/domain/constant/CategoryArea.java
+++ b/src/main/java/team/incude/gsmc/v2/domain/sheet/domain/constant/CategoryArea.java
@@ -11,7 +11,4 @@ public enum CategoryArea {
         this.displayName = d;
     }
 
-    public String getDisplayName() {
-        return displayName;
-    }
 }

--- a/src/main/java/team/incude/gsmc/v2/global/error/ErrorCode.java
+++ b/src/main/java/team/incude/gsmc/v2/global/error/ErrorCode.java
@@ -60,6 +60,7 @@ public enum ErrorCode {
     // Email Authentication
     EMAIL_FORMAT_INVALID("Email Format Invalid", HttpStatus.UNAUTHORIZED.value()),
     VERIFICATION_INVALID("Verification Invalid", HttpStatus.UNAUTHORIZED.value()),
+    EMAIL_SEND_FAILED("Email Send Failed", HttpStatus.INTERNAL_SERVER_ERROR.value()),
 
     // Evidence
     EVIDENCE_NOT_FOUND("Evidence Not Found", HttpStatus.NOT_FOUND.value()),

--- a/src/main/java/team/incude/gsmc/v2/global/event/DraftEvidenceDeleteEvent.java
+++ b/src/main/java/team/incude/gsmc/v2/global/event/DraftEvidenceDeleteEvent.java
@@ -1,12 +1,6 @@
 package team.incude.gsmc.v2.global.event;
 
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
-
 import java.util.UUID;
 
-@RequiredArgsConstructor
-@Getter
-public class DraftEvidenceDeleteEvent {
-    private final UUID draftId;
+public record DraftEvidenceDeleteEvent(UUID draftId) {
 }

--- a/src/main/java/team/incude/gsmc/v2/global/event/handler/DraftEvidenceDeleteEventListener.java
+++ b/src/main/java/team/incude/gsmc/v2/global/event/handler/DraftEvidenceDeleteEventListener.java
@@ -18,7 +18,7 @@ public class DraftEvidenceDeleteEventListener {
     @Async
     @EventListener(DraftEvidenceDeleteEvent.class)
     public void handleDraftEvidenceDeleteEvent(DraftEvidenceDeleteEvent event) {
-        activityEvidencePersistencePort.deleteDraftActivityEvidenceById(event.getDraftId());
-        readingEvidencePersistencePort.deleteDraftReadingEvidenceById(event.getDraftId());
+        activityEvidencePersistencePort.deleteDraftActivityEvidenceById(event.draftId());
+        readingEvidencePersistencePort.deleteDraftReadingEvidenceById(event.draftId());
     }
 }

--- a/src/main/java/team/incude/gsmc/v2/global/thirdparty/aws/s3/usecase/service/FileDeleteService.java
+++ b/src/main/java/team/incude/gsmc/v2/global/thirdparty/aws/s3/usecase/service/FileDeleteService.java
@@ -40,9 +40,8 @@ public class FileDeleteService implements FileDeleteUseCase {
                 .bucket(bucketName)
                 .key(uniqueFileName)
                 .build();
-        return s3AsyncClient.deleteObject(deleteObjectRequest).thenAccept(response -> {
-            log.info("File deleted successfully: {}", uniqueFileName);
-        }).exceptionally(throwable -> {
+        return s3AsyncClient.deleteObject(deleteObjectRequest).thenAccept(response -> log.info("File deleted successfully: {}", uniqueFileName)
+        ).exceptionally(throwable -> {
             log.error("Failed to delete file: {}", uniqueFileName, throwable);
             throw new S3DeleteFailedException();
         });

--- a/src/main/java/team/incude/gsmc/v2/global/thirdparty/email/application/usecase/service/EmailSendService.java
+++ b/src/main/java/team/incude/gsmc/v2/global/thirdparty/email/application/usecase/service/EmailSendService.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Service;
 import org.thymeleaf.TemplateEngine;
 import org.thymeleaf.context.Context;
 import team.incude.gsmc.v2.global.thirdparty.email.application.usecase.EmailSendUseCase;
+import team.incude.gsmc.v2.global.thirdparty.email.exception.EmailSendFailedException;
 
 @Service
 @RequiredArgsConstructor
@@ -33,6 +34,7 @@ public class EmailSendService implements EmailSendUseCase {
             helper.setText(html, true);
             mailSender.send(message);
         } catch (MessagingException e) {
+            throw new EmailSendFailedException();
         }
     }
 }

--- a/src/main/java/team/incude/gsmc/v2/global/thirdparty/email/exception/EmailSendFailedException.java
+++ b/src/main/java/team/incude/gsmc/v2/global/thirdparty/email/exception/EmailSendFailedException.java
@@ -1,0 +1,10 @@
+package team.incude.gsmc.v2.global.thirdparty.email.exception;
+
+import team.incude.gsmc.v2.global.error.ErrorCode;
+import team.incude.gsmc.v2.global.error.exception.GsmcException;
+
+public class EmailSendFailedException extends GsmcException {
+    public EmailSendFailedException() {
+        super(ErrorCode.EMAIL_SEND_FAILED);
+    }
+}

--- a/src/test/java/team/incude/gsmc/v2/domain/member/application/usecase/service/FindCurrentStudentServiceTest.java
+++ b/src/test/java/team/incude/gsmc/v2/domain/member/application/usecase/service/FindCurrentStudentServiceTest.java
@@ -20,7 +20,7 @@ import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("현재 로그인된 학생 조회 서비스 클래스의")
-class FindCurrentCurrentStudentServiceTest {
+class FindCurrentStudentServiceTest {
 
     @Mock
     private StudentDetailPersistencePort studentDetailPersistencePort;
@@ -29,7 +29,7 @@ class FindCurrentCurrentStudentServiceTest {
     private CurrentMemberProvider currentMemberProvider;
 
     @InjectMocks
-    private FindCurrentCurrentStudentService findCurrentCurrentStudentService;
+    private FindCurrentStudentService findCurrentStudentService;
 
     @Nested
     @DisplayName("execute() 메서드는")
@@ -66,7 +66,7 @@ class FindCurrentCurrentStudentServiceTest {
                         .thenReturn(studentDetailWithEvidence);
 
                 // when
-                GetStudentResponse response = findCurrentCurrentStudentService.execute();
+                GetStudentResponse response = findCurrentStudentService.execute();
 
                 // then
                 assertThat(response.email()).isEqualTo(email);

--- a/src/test/java/team/incude/gsmc/v2/domain/member/application/usecase/service/SearchStudentServiceTest.java
+++ b/src/test/java/team/incude/gsmc/v2/domain/member/application/usecase/service/SearchStudentServiceTest.java
@@ -75,7 +75,7 @@ class SearchStudentServiceTest {
                         1
                 );
 
-                when(studentDetailPersistencePort.searchStudentDetailWithEvidenceReiewStatusNotNullMember(
+                when(studentDetailPersistencePort.searchStudentDetailWithEvidenceReviewStatusNotNullMember(
                         name, grade, classNumber, PageRequest.ofSize(size)
                 )).thenReturn(studentPage);
 
@@ -117,7 +117,7 @@ class SearchStudentServiceTest {
                         0
                 );
 
-                when(studentDetailPersistencePort.searchStudentDetailWithEvidenceReiewStatusNotNullMember(
+                when(studentDetailPersistencePort.searchStudentDetailWithEvidenceReviewStatusNotNullMember(
                         name, grade, classNumber, PageRequest.ofSize(size)
                 )).thenReturn(emptyPage);
 


### PR DESCRIPTION
## 📋 작업 내용
> ``ResponseEntity<Object>``로 선언되어 자료형 지정이 불명확하던 ``MemberWebAdapter`` 클래스를 개선하여 각 메서드가 알맞은 객체만을 반환하는 걸 허용하도록 강제하였습니다

## 🤝 리뷰 시 참고사항
> #82 이 먼저 머지되거나 클로즈된 후 이 PR이 머지되도록 하면 좋겠습니다

## ✅ 체크리스트
- [x] 이 작업으로 인해 변경이 필요한 문서를 작성 또는 수정했나요? (e.g. `README`, `.env.example`)
- [x] 작업한 코드가 정상적으로 동작하는지 확인했나요?
- [x] 작업한 코드에 대한 테스트 코드를 작성하거나 수정했나요?
- [x] Merge 대상 브랜치를 올바르게 설정했나요?
- [x] 해당 PR과 관련 없는 작업이 포함되지는 않았나요?
- [x] PR의 올바른 라벨과 리뷰어를 설정했나요?