### PR TITLE
증빙자료 관련 임시 저장 조회 서비스 구현 및 score 생성 로직 구현

### DIFF
--- a/src/main/java/team/incude/gsmc/v2/domain/evidence/application/EvidenceApplicationAdapter.java
+++ b/src/main/java/team/incude/gsmc/v2/domain/evidence/application/EvidenceApplicationAdapter.java
@@ -33,6 +33,7 @@ public class EvidenceApplicationAdapter implements EvidenceApplicationPort {
     private final CreateDraftReadingEvidenceUseCase createDraftReadingEvidenceUseCase;
     private final FindDraftActivityEvidenceByDraftIdUseCase findDraftActivityEvidenceUseCase;
     private final FindDraftReadingEvidenceByDraftIdUseCase findDraftReadingEvidenceUseCase;
+    private final FindDraftEvidenceByCurrentUserUseCase findDraftEvidenceByCurrentUserUseCase;
 
     @Override
     public GetEvidencesResponse findEvidenceByCurrentUserAndType(EvidenceType evidenceType) {
@@ -122,5 +123,10 @@ public class EvidenceApplicationAdapter implements EvidenceApplicationPort {
     @Override
     public GetDraftReadingEvidenceResponse findDraftReadingEvidenceByDraftId(UUID draftId) {
         return findDraftReadingEvidenceUseCase.execute(draftId);
+    }
+
+    @Override
+    public GetDraftEvidenceResponse findDraftEvidenceByCurrentUser() {
+        return findDraftEvidenceByCurrentUserUseCase.execute();
     }
 }

--- a/src/main/java/team/incude/gsmc/v2/domain/evidence/application/port/ActivityEvidencePersistencePort.java
+++ b/src/main/java/team/incude/gsmc/v2/domain/evidence/application/port/ActivityEvidencePersistencePort.java
@@ -7,7 +7,6 @@ import team.incude.gsmc.v2.global.annotation.PortDirection;
 import team.incude.gsmc.v2.global.annotation.port.Port;
 
 import java.util.List;
-import java.util.UUID;
 
 @Port(direction = PortDirection.OUTBOUND)
 public interface ActivityEvidencePersistencePort {

--- a/src/main/java/team/incude/gsmc/v2/domain/evidence/application/port/DraftActivityEvidencePersistencePort.java
+++ b/src/main/java/team/incude/gsmc/v2/domain/evidence/application/port/DraftActivityEvidencePersistencePort.java
@@ -4,6 +4,7 @@ import team.incude.gsmc.v2.domain.evidence.domain.DraftActivityEvidence;
 import team.incude.gsmc.v2.global.annotation.PortDirection;
 import team.incude.gsmc.v2.global.annotation.port.Port;
 
+import java.util.List;
 import java.util.UUID;
 
 @Port(direction = PortDirection.OUTBOUND)
@@ -13,4 +14,6 @@ public interface DraftActivityEvidencePersistencePort {
     DraftActivityEvidence findDraftActivityEvidenceById(UUID draftId);
 
     void deleteDraftActivityEvidenceById(UUID draftId);
+
+    List<DraftActivityEvidence> findAllDraftActivityEvidenceByEmail(String email);
 }

--- a/src/main/java/team/incude/gsmc/v2/domain/evidence/application/port/DraftReadingEvidencePersistencePort.java
+++ b/src/main/java/team/incude/gsmc/v2/domain/evidence/application/port/DraftReadingEvidencePersistencePort.java
@@ -4,6 +4,7 @@ import team.incude.gsmc.v2.domain.evidence.domain.DraftReadingEvidence;
 import team.incude.gsmc.v2.global.annotation.PortDirection;
 import team.incude.gsmc.v2.global.annotation.port.Port;
 
+import java.util.List;
 import java.util.UUID;
 
 @Port(direction = PortDirection.OUTBOUND)
@@ -13,4 +14,6 @@ public interface DraftReadingEvidencePersistencePort {
     DraftReadingEvidence findDraftReadingEvidenceById(UUID draftId);
 
     void deleteDraftReadingEvidenceById(UUID draftId);
+
+    List<DraftReadingEvidence> findAllDraftReadingEvidenceByEmail(String email);
 }

--- a/src/main/java/team/incude/gsmc/v2/domain/evidence/application/port/EvidenceApplicationPort.java
+++ b/src/main/java/team/incude/gsmc/v2/domain/evidence/application/port/EvidenceApplicationPort.java
@@ -46,4 +46,6 @@ public interface EvidenceApplicationPort {
     GetDraftActivityEvidenceResponse findDraftActivityEvidenceByDraftId(UUID draftId);
 
     GetDraftReadingEvidenceResponse findDraftReadingEvidenceByDraftId(UUID draftId);
+
+    GetDraftEvidenceResponse findDraftEvidenceByCurrentUser();
 }

--- a/src/main/java/team/incude/gsmc/v2/domain/evidence/application/usecase/FindDraftEvidenceByCurrentUserUseCase.java
+++ b/src/main/java/team/incude/gsmc/v2/domain/evidence/application/usecase/FindDraftEvidenceByCurrentUserUseCase.java
@@ -1,0 +1,7 @@
+package team.incude.gsmc.v2.domain.evidence.application.usecase;
+
+import team.incude.gsmc.v2.domain.evidence.presentation.data.response.GetDraftEvidenceResponse;
+
+public interface FindDraftEvidenceByCurrentUserUseCase {
+    GetDraftEvidenceResponse execute();
+}

--- a/src/main/java/team/incude/gsmc/v2/domain/evidence/application/usecase/service/CreateActivityEvidenceService.java
+++ b/src/main/java/team/incude/gsmc/v2/domain/evidence/application/usecase/service/CreateActivityEvidenceService.java
@@ -15,12 +15,16 @@ import team.incude.gsmc.v2.domain.evidence.domain.constant.ReviewStatus;
 import team.incude.gsmc.v2.domain.member.application.port.StudentDetailPersistencePort;
 import team.incude.gsmc.v2.domain.member.domain.Member;
 import team.incude.gsmc.v2.domain.member.domain.StudentDetail;
+import team.incude.gsmc.v2.domain.score.application.port.CategoryPersistencePort;
 import team.incude.gsmc.v2.domain.score.application.port.ScorePersistencePort;
+import team.incude.gsmc.v2.domain.score.domain.Category;
 import team.incude.gsmc.v2.domain.score.domain.Score;
+import team.incude.gsmc.v2.domain.score.exception.ScoreLimitExceededException;
 import team.incude.gsmc.v2.global.event.DraftEvidenceDeleteEvent;
 import team.incude.gsmc.v2.global.event.ScoreUpdatedEvent;
 import team.incude.gsmc.v2.global.security.jwt.usecase.service.CurrentMemberProvider;
 import team.incude.gsmc.v2.global.thirdparty.aws.exception.S3UploadFailedException;
+import team.incude.gsmc.v2.global.util.ValueLimiterUtil;
 
 import java.io.IOException;
 import java.time.LocalDateTime;
@@ -32,6 +36,7 @@ import java.util.UUID;
 public class CreateActivityEvidenceService implements CreateActivityEvidenceUseCase {
 
     private final ActivityEvidencePersistencePort activityEvidencePersistencePort;
+    private final CategoryPersistencePort categoryPersistencePort;
     private final ScorePersistencePort scorePersistencePort;
     private final StudentDetailPersistencePort studentDetailPersistencePort;
     private final S3Port s3Port;
@@ -44,12 +49,18 @@ public class CreateActivityEvidenceService implements CreateActivityEvidenceUseC
         StudentDetail studentDetail = studentDetailPersistencePort.findStudentDetailByMemberEmail(member.getEmail());
         Score score = scorePersistencePort.findScoreByCategoryNameAndStudentDetailStudentCodeWithLock(categoryName, studentDetail.getStudentCode());
 
+        if (score == null) {
+            score = createScore(categoryName, member);
+        } else if (ValueLimiterUtil.isExceedingLimit(score.getValue() + 1, score.getCategory().getMaximumValue())) {
+            throw new ScoreLimitExceededException();
+        }
+
         score.plusValue(1);
+        scorePersistencePort.saveScore(score);
 
         Evidence evidence = createEvidence(score, activityType);
         ActivityEvidence activityEvidence = createActivityEvidence(evidence, title, content, file, imageUrl);
 
-        scorePersistencePort.saveScore(score);
         activityEvidencePersistencePort.saveActivityEvidence(activityEvidence);
         applicationEventPublisher.publishEvent(new ScoreUpdatedEvent(studentDetail.getStudentCode()));
         applicationEventPublisher.publishEvent(new DraftEvidenceDeleteEvent(draftId));
@@ -91,5 +102,14 @@ public class CreateActivityEvidenceService implements CreateActivityEvidenceUseC
         } catch (IOException e) {
             throw new S3UploadFailedException();
         }
+    }
+
+    private Score createScore(String categoryName, Member member) {
+        Category category = categoryPersistencePort.findCategoryByName(categoryName);
+        return Score.builder()
+                .category(category)
+                .value(0)
+                .member(member)
+                .build();
     }
 }

--- a/src/main/java/team/incude/gsmc/v2/domain/evidence/application/usecase/service/CreateOtherEvidenceService.java
+++ b/src/main/java/team/incude/gsmc/v2/domain/evidence/application/usecase/service/CreateOtherEvidenceService.java
@@ -15,16 +15,19 @@ import team.incude.gsmc.v2.domain.evidence.domain.constant.ReviewStatus;
 import team.incude.gsmc.v2.domain.member.application.port.StudentDetailPersistencePort;
 import team.incude.gsmc.v2.domain.member.domain.Member;
 import team.incude.gsmc.v2.domain.member.domain.StudentDetail;
+import team.incude.gsmc.v2.domain.score.application.port.CategoryPersistencePort;
 import team.incude.gsmc.v2.domain.score.application.port.ScorePersistencePort;
+import team.incude.gsmc.v2.domain.score.domain.Category;
 import team.incude.gsmc.v2.domain.score.domain.Score;
+import team.incude.gsmc.v2.domain.score.exception.ScoreLimitExceededException;
 import team.incude.gsmc.v2.global.event.ScoreUpdatedEvent;
 import team.incude.gsmc.v2.global.security.jwt.usecase.service.CurrentMemberProvider;
 import team.incude.gsmc.v2.global.thirdparty.aws.exception.S3UploadFailedException;
+import team.incude.gsmc.v2.global.util.ValueLimiterUtil;
 
 import java.io.IOException;
 import java.time.LocalDateTime;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 
 @Service
 @RequiredArgsConstructor
@@ -37,23 +40,29 @@ public class CreateOtherEvidenceService implements CreateOtherEvidenceUseCase {
     private final ScorePersistencePort scorePersistencePort;
     private final CurrentMemberProvider currentMemberProvider;
     private final ApplicationEventPublisher applicationEventPublisher;
+    private final CategoryPersistencePort categoryPersistencePort;
 
     @Override
     public void execute(String categoryName, MultipartFile file) {
         Member member = currentMemberProvider.getCurrentUser();
         StudentDetail studentDetail = studentDetailPersistencePort.findStudentDetailByMemberEmail(member.getEmail());
         Score score = scorePersistencePort.findScoreByCategoryNameAndStudentDetailStudentCodeWithLock(categoryName, studentDetail.getStudentCode());
+
+        if (score == null) {
+            score = createScore(categoryName, member);
+        } else if (ValueLimiterUtil.isExceedingLimit(score.getValue() + 1, score.getCategory().getMaximumValue())) {
+            throw new ScoreLimitExceededException();
+        }
         score.plusValue(1);
+        scorePersistencePort.saveScore(score);
 
         EvidenceType evidenceType = categoryMap.get(categoryName);
         Evidence evidence = createEvidence(score, evidenceType);
         OtherEvidence otherEvidence = createOtherEvidence(evidence, file);
 
-        scorePersistencePort.saveScore(score);
         otherEvidencePersistencePort.saveOtherEvidence(otherEvidence);
         applicationEventPublisher.publishEvent(new ScoreUpdatedEvent(studentDetail.getStudentCode()));
     }
-
 
     private Evidence createEvidence(Score score, EvidenceType evidenceType) {
         return Evidence.builder()
@@ -84,9 +93,16 @@ public class CreateOtherEvidenceService implements CreateOtherEvidenceUseCase {
         }
     }
 
+    private Score createScore(String categoryName, Member member) {
+        Category category = categoryPersistencePort.findCategoryByName(categoryName);
+        return Score.builder()
+                .category(category)
+                .value(0)
+                .member(member)
+                .build();
+    }
+
     private static final Map<String, EvidenceType> categoryMap = Map.ofEntries(
-            Map.entry("HUMANITIES-CERTIFICATE-CHINESE_CHARACTER", EvidenceType.CERTIFICATE),
-            Map.entry("HUMANITIES-CERTIFICATE-KOREAN_HISTORY", EvidenceType.CERTIFICATE),
             Map.entry("HUMANITIES-READING-READ_A_THON-TURTLE", EvidenceType.READ_A_THON),
             Map.entry("HUMANITIES-READING-READ_A_THON-CROCODILE", EvidenceType.READ_A_THON),
             Map.entry("HUMANITIES-READING-READ_A_THON-RABBIT_OVER", EvidenceType.READ_A_THON)

--- a/src/main/java/team/incude/gsmc/v2/domain/evidence/application/usecase/service/CreateOtherScoringEvidenceService.java
+++ b/src/main/java/team/incude/gsmc/v2/domain/evidence/application/usecase/service/CreateOtherScoringEvidenceService.java
@@ -15,11 +15,15 @@ import team.incude.gsmc.v2.domain.evidence.domain.constant.ReviewStatus;
 import team.incude.gsmc.v2.domain.member.application.port.StudentDetailPersistencePort;
 import team.incude.gsmc.v2.domain.member.domain.Member;
 import team.incude.gsmc.v2.domain.member.domain.StudentDetail;
+import team.incude.gsmc.v2.domain.score.application.port.CategoryPersistencePort;
 import team.incude.gsmc.v2.domain.score.application.port.ScorePersistencePort;
+import team.incude.gsmc.v2.domain.score.domain.Category;
 import team.incude.gsmc.v2.domain.score.domain.Score;
+import team.incude.gsmc.v2.domain.score.exception.ScoreLimitExceededException;
 import team.incude.gsmc.v2.global.event.ScoreUpdatedEvent;
 import team.incude.gsmc.v2.global.security.jwt.usecase.service.CurrentMemberProvider;
 import team.incude.gsmc.v2.global.thirdparty.aws.exception.S3UploadFailedException;
+import team.incude.gsmc.v2.global.util.ValueLimiterUtil;
 
 import java.io.IOException;
 import java.time.LocalDateTime;
@@ -36,22 +40,43 @@ public class CreateOtherScoringEvidenceService implements CreateOtherScoringEvid
     private final CurrentMemberProvider currentMemberProvider;
     private final ApplicationEventPublisher applicationEventPublisher;
     private final OtherEvidencePersistencePort otherEvidencePersistencePort;
+    private final CategoryPersistencePort categoryPersistencePort;
 
     @Override
     public void execute(String categoryName, MultipartFile file, int value) {
         Member member = currentMemberProvider.getCurrentUser();
         StudentDetail studentDetail = studentDetailPersistencePort.findStudentDetailByMemberEmail(member.getEmail());
         Score score = scorePersistencePort.findScoreByCategoryNameAndStudentDetailStudentCodeWithLock(categoryName, studentDetail.getStudentCode());
+        Category category = categoryPersistencePort.findCategoryByName(categoryName);
+        checkValueByMaximumValue(category, value);
 
-        Score newScore = createScore(score, value);
+        if (score == null) {
+            score = createScore(value, category, member);
+        } else {
+            score = createScore(score, value);
+        }
 
         EvidenceType evidenceType = categoryMap.get(categoryName);
         Evidence evidence = createEvidence(score, evidenceType);
         OtherEvidence otherEvidence = createOtherEvidence(evidence, file);
 
-        scorePersistencePort.saveScore(newScore);
+        scorePersistencePort.saveScore(score);
         otherEvidencePersistencePort.saveOtherEvidence(otherEvidence);
         applicationEventPublisher.publishEvent(new ScoreUpdatedEvent(studentDetail.getStudentCode()));
+    }
+
+    private void checkValueByMaximumValue(Category category, int value) {
+        if (ValueLimiterUtil.isExceedingLimit(value, category.getMaximumValue())) {
+            throw new ScoreLimitExceededException();
+        }
+    }
+
+    private Score createScore(int value, Category category, Member member) {
+        return Score.builder()
+                .value(value)
+                .category(category)
+                .member(member)
+                .build();
     }
 
     private Score createScore(Score score, int value) {

--- a/src/main/java/team/incude/gsmc/v2/domain/evidence/application/usecase/service/FindDraftEvidenceByCurrentUserService.java
+++ b/src/main/java/team/incude/gsmc/v2/domain/evidence/application/usecase/service/FindDraftEvidenceByCurrentUserService.java
@@ -1,0 +1,63 @@
+package team.incude.gsmc.v2.domain.evidence.application.usecase.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import team.incude.gsmc.v2.domain.evidence.application.port.DraftActivityEvidencePersistencePort;
+import team.incude.gsmc.v2.domain.evidence.application.port.DraftReadingEvidencePersistencePort;
+import team.incude.gsmc.v2.domain.evidence.application.usecase.FindDraftEvidenceByCurrentUserUseCase;
+import team.incude.gsmc.v2.domain.evidence.domain.DraftActivityEvidence;
+import team.incude.gsmc.v2.domain.evidence.domain.DraftReadingEvidence;
+import team.incude.gsmc.v2.domain.evidence.presentation.data.response.GetDraftActivityEvidenceResponse;
+import team.incude.gsmc.v2.domain.evidence.presentation.data.response.GetDraftEvidenceResponse;
+import team.incude.gsmc.v2.domain.evidence.presentation.data.response.GetDraftReadingEvidenceResponse;
+import team.incude.gsmc.v2.domain.member.domain.Member;
+import team.incude.gsmc.v2.global.security.jwt.usecase.service.CurrentMemberProvider;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class FindDraftEvidenceByCurrentUserService implements FindDraftEvidenceByCurrentUserUseCase {
+
+    private final DraftActivityEvidencePersistencePort draftActivityEvidencePersistencePort;
+    private final DraftReadingEvidencePersistencePort draftReadingEvidencePersistencePort;
+    private final CurrentMemberProvider currentMemberProvider;
+
+    @Override
+    public GetDraftEvidenceResponse execute() {
+        Member member = currentMemberProvider.getCurrentUser();
+
+        List<DraftActivityEvidence> activityEvidences = draftActivityEvidencePersistencePort.findAllDraftActivityEvidenceByEmail(member.getEmail());
+        List<DraftReadingEvidence> readingEvidences = draftReadingEvidencePersistencePort.findAllDraftReadingEvidenceByEmail(member.getEmail());
+
+        List<GetDraftActivityEvidenceResponse> activityEvidenceResponses = createDraftActivityResponse(activityEvidences);
+        List<GetDraftReadingEvidenceResponse> readingEvidenceResponses = createDraftReadingResponse(readingEvidences);
+
+        return new GetDraftEvidenceResponse(activityEvidenceResponses, readingEvidenceResponses);
+    }
+
+    private List<GetDraftActivityEvidenceResponse> createDraftActivityResponse(List<DraftActivityEvidence> activityEvidences) {
+        return activityEvidences.stream()
+                .map(e -> new GetDraftActivityEvidenceResponse(
+                        e.getId(),
+                        e.getTitle(),
+                        e.getContent(),
+                        e.getImageUrl(),
+                        e.getCategoryName(),
+                        e.getEvidenceType()
+                ))
+                .toList();
+    }
+
+    private List<GetDraftReadingEvidenceResponse> createDraftReadingResponse(List<DraftReadingEvidence> readingEvidences) {
+        return readingEvidences.stream()
+                .map(e -> new GetDraftReadingEvidenceResponse(
+                        e.getId(),
+                        e.getTitle(),
+                        e.getAuthor(),
+                        e.getPage(),
+                        e.getContent()
+                ))
+                .toList();
+    }
+}

--- a/src/main/java/team/incude/gsmc/v2/domain/evidence/domain/DraftActivityEvidence.java
+++ b/src/main/java/team/incude/gsmc/v2/domain/evidence/domain/DraftActivityEvidence.java
@@ -16,4 +16,5 @@ public class DraftActivityEvidence {
     private String imageUrl;
     private EvidenceType evidenceType;
     private Long ttl;
+    private String email;
 }

--- a/src/main/java/team/incude/gsmc/v2/domain/evidence/domain/DraftReadingEvidence.java
+++ b/src/main/java/team/incude/gsmc/v2/domain/evidence/domain/DraftReadingEvidence.java
@@ -14,4 +14,5 @@ public class DraftReadingEvidence {
     private Integer page;
     private String content;
     private Long ttl;
+    private String email;
 }

--- a/src/main/java/team/incude/gsmc/v2/domain/evidence/domain/ReadingEvidence.java
+++ b/src/main/java/team/incude/gsmc/v2/domain/evidence/domain/ReadingEvidence.java
@@ -1,9 +1,7 @@
 package team.incude.gsmc.v2.domain.evidence.domain;
 
-import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
-import team.incude.gsmc.v2.domain.evidence.persistence.entity.EvidenceJpaEntity;
 
 @Getter
 @Builder

--- a/src/main/java/team/incude/gsmc/v2/domain/evidence/persistence/DraftActivityEvidencePersistenceAdapter.java
+++ b/src/main/java/team/incude/gsmc/v2/domain/evidence/persistence/DraftActivityEvidencePersistenceAdapter.java
@@ -9,6 +9,7 @@ import team.incude.gsmc.v2.domain.evidence.persistence.repository.DraftActivityE
 import team.incude.gsmc.v2.global.annotation.PortDirection;
 import team.incude.gsmc.v2.global.annotation.adapter.Adapter;
 
+import java.util.List;
 import java.util.UUID;
 
 @Adapter(direction = PortDirection.OUTBOUND)
@@ -34,6 +35,14 @@ public class DraftActivityEvidencePersistenceAdapter implements DraftActivityEvi
     @Override
     public void deleteDraftActivityEvidenceById(UUID draftId) {
         draftActivityEvidenceRedisRepository.deleteById(draftId);
+    }
+
+    @Override
+    public List<DraftActivityEvidence> findAllDraftActivityEvidenceByEmail(String email) {
+        return draftActivityEvidenceRedisRepository.findByEmail(email)
+                .stream()
+                .map(activityEvidenceMapper::toDraftDomain)
+                .toList();
     }
 
 }

--- a/src/main/java/team/incude/gsmc/v2/domain/evidence/persistence/DraftReadingEvidencePersistenceAdapter.java
+++ b/src/main/java/team/incude/gsmc/v2/domain/evidence/persistence/DraftReadingEvidencePersistenceAdapter.java
@@ -9,6 +9,7 @@ import team.incude.gsmc.v2.domain.evidence.persistence.repository.DraftReadingEv
 import team.incude.gsmc.v2.global.annotation.PortDirection;
 import team.incude.gsmc.v2.global.annotation.adapter.Adapter;
 
+import java.util.List;
 import java.util.UUID;
 
 @Adapter(direction = PortDirection.OUTBOUND)
@@ -33,5 +34,13 @@ public class DraftReadingEvidencePersistenceAdapter implements DraftReadingEvide
     @Override
     public void deleteDraftReadingEvidenceById(UUID draftId) {
         draftReadingEvidenceRedisRepository.deleteById(draftId);
+    }
+
+    @Override
+    public List<DraftReadingEvidence> findAllDraftReadingEvidenceByEmail(String email) {
+        return draftReadingEvidenceRedisRepository.findByEmail(email)
+                .stream()
+                .map(readingEvidenceMapper::toDraftDomain)
+                .toList();
     }
 }

--- a/src/main/java/team/incude/gsmc/v2/domain/evidence/persistence/entity/DraftActivityEvidenceRedisEntity.java
+++ b/src/main/java/team/incude/gsmc/v2/domain/evidence/persistence/entity/DraftActivityEvidenceRedisEntity.java
@@ -11,7 +11,7 @@ import team.incude.gsmc.v2.domain.evidence.domain.constant.EvidenceType;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
-@RedisHash(value = "activityEvidence")
+@RedisHash(value = "draftActivityEvidence")
 @Getter
 public class DraftActivityEvidenceRedisEntity {
     @Id

--- a/src/main/java/team/incude/gsmc/v2/domain/evidence/persistence/entity/DraftActivityEvidenceRedisEntity.java
+++ b/src/main/java/team/incude/gsmc/v2/domain/evidence/persistence/entity/DraftActivityEvidenceRedisEntity.java
@@ -11,7 +11,7 @@ import team.incude.gsmc.v2.domain.evidence.domain.constant.EvidenceType;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
-@RedisHash(value = "draftActivityEvidence")
+@RedisHash(value = "draft_activity_evidence")
 @Getter
 public class DraftActivityEvidenceRedisEntity {
     @Id

--- a/src/main/java/team/incude/gsmc/v2/domain/evidence/persistence/entity/DraftActivityEvidenceRedisEntity.java
+++ b/src/main/java/team/incude/gsmc/v2/domain/evidence/persistence/entity/DraftActivityEvidenceRedisEntity.java
@@ -5,6 +5,7 @@ import lombok.Builder;
 import lombok.Getter;
 import org.springframework.data.redis.core.RedisHash;
 import org.springframework.data.redis.core.TimeToLive;
+import org.springframework.data.redis.core.index.Indexed;
 import team.incude.gsmc.v2.domain.evidence.domain.constant.EvidenceType;
 
 import java.util.UUID;
@@ -22,9 +23,11 @@ public class DraftActivityEvidenceRedisEntity {
     private EvidenceType evidenceType;
     @TimeToLive(unit = TimeUnit.SECONDS)
     private Long ttl;
+    @Indexed
+    private String email;
 
     @Builder
-    public DraftActivityEvidenceRedisEntity(UUID id, String categoryName, String title, String content, String imageUrl, EvidenceType evidenceType, Long ttl) {
+    public DraftActivityEvidenceRedisEntity(UUID id, String categoryName, String title, String content, String imageUrl, EvidenceType evidenceType, Long ttl, String email) {
         this.id = id;
         this.categoryName = categoryName;
         this.title = title;
@@ -32,5 +35,6 @@ public class DraftActivityEvidenceRedisEntity {
         this.imageUrl = imageUrl;
         this.evidenceType = evidenceType;
         this.ttl = ttl;
+        this.email = email;
     }
 }

--- a/src/main/java/team/incude/gsmc/v2/domain/evidence/persistence/entity/DraftReadingEvidenceRedisEntity.java
+++ b/src/main/java/team/incude/gsmc/v2/domain/evidence/persistence/entity/DraftReadingEvidenceRedisEntity.java
@@ -10,7 +10,7 @@ import org.springframework.data.redis.core.index.Indexed;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
-@RedisHash(value = "readingEvidence")
+@RedisHash(value = "draftReadingEvidence")
 @Getter
 public class DraftReadingEvidenceRedisEntity {
     @Id

--- a/src/main/java/team/incude/gsmc/v2/domain/evidence/persistence/entity/DraftReadingEvidenceRedisEntity.java
+++ b/src/main/java/team/incude/gsmc/v2/domain/evidence/persistence/entity/DraftReadingEvidenceRedisEntity.java
@@ -10,7 +10,7 @@ import org.springframework.data.redis.core.index.Indexed;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
-@RedisHash(value = "draftReadingEvidence")
+@RedisHash(value = "draft_reading_evidence")
 @Getter
 public class DraftReadingEvidenceRedisEntity {
     @Id

--- a/src/main/java/team/incude/gsmc/v2/domain/evidence/persistence/entity/DraftReadingEvidenceRedisEntity.java
+++ b/src/main/java/team/incude/gsmc/v2/domain/evidence/persistence/entity/DraftReadingEvidenceRedisEntity.java
@@ -5,6 +5,7 @@ import lombok.Builder;
 import lombok.Getter;
 import org.springframework.data.redis.core.RedisHash;
 import org.springframework.data.redis.core.TimeToLive;
+import org.springframework.data.redis.core.index.Indexed;
 
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
@@ -20,14 +21,17 @@ public class DraftReadingEvidenceRedisEntity {
     private String content;
     @TimeToLive(unit = TimeUnit.SECONDS)
     private Long ttl;
+    @Indexed
+    private String email;
 
     @Builder
-    public DraftReadingEvidenceRedisEntity(UUID id, String title, String author, Integer page, String content, Long ttl) {
+    public DraftReadingEvidenceRedisEntity(UUID id, String title, String author, Integer page, String content, Long ttl, String email) {
         this.id = id;
         this.title = title;
         this.author = author;
         this.page = page;
         this.content = content;
         this.ttl = ttl;
+        this.email = email;
     }
 }

--- a/src/main/java/team/incude/gsmc/v2/domain/evidence/persistence/repository/DraftActivityEvidenceRedisRepository.java
+++ b/src/main/java/team/incude/gsmc/v2/domain/evidence/persistence/repository/DraftActivityEvidenceRedisRepository.java
@@ -3,7 +3,9 @@ package team.incude.gsmc.v2.domain.evidence.persistence.repository;
 import org.springframework.data.repository.CrudRepository;
 import team.incude.gsmc.v2.domain.evidence.persistence.entity.DraftActivityEvidenceRedisEntity;
 
+import java.util.List;
 import java.util.UUID;
 
 public interface DraftActivityEvidenceRedisRepository extends CrudRepository<DraftActivityEvidenceRedisEntity, UUID> {
+    List<DraftActivityEvidenceRedisEntity> findByEmail(String email);
 }

--- a/src/main/java/team/incude/gsmc/v2/domain/evidence/persistence/repository/DraftReadingEvidenceRedisRepository.java
+++ b/src/main/java/team/incude/gsmc/v2/domain/evidence/persistence/repository/DraftReadingEvidenceRedisRepository.java
@@ -3,7 +3,9 @@ package team.incude.gsmc.v2.domain.evidence.persistence.repository;
 import org.springframework.data.repository.CrudRepository;
 import team.incude.gsmc.v2.domain.evidence.persistence.entity.DraftReadingEvidenceRedisEntity;
 
+import java.util.List;
 import java.util.UUID;
 
 public interface DraftReadingEvidenceRedisRepository extends CrudRepository<DraftReadingEvidenceRedisEntity, UUID> {
+    List<DraftReadingEvidenceRedisEntity> findByEmail(String email);
 }

--- a/src/main/java/team/incude/gsmc/v2/domain/evidence/presentation/EvidenceWebAdapter.java
+++ b/src/main/java/team/incude/gsmc/v2/domain/evidence/presentation/EvidenceWebAdapter.java
@@ -8,10 +8,7 @@ import team.incude.gsmc.v2.domain.evidence.application.port.EvidenceApplicationP
 import team.incude.gsmc.v2.domain.evidence.domain.constant.EvidenceType;
 import team.incude.gsmc.v2.domain.evidence.domain.constant.ReviewStatus;
 import team.incude.gsmc.v2.domain.evidence.presentation.data.request.*;
-import team.incude.gsmc.v2.domain.evidence.presentation.data.response.CreateDraftEvidenceResponse;
-import team.incude.gsmc.v2.domain.evidence.presentation.data.response.GetDraftActivityEvidenceResponse;
-import team.incude.gsmc.v2.domain.evidence.presentation.data.response.GetDraftReadingEvidenceResponse;
-import team.incude.gsmc.v2.domain.evidence.presentation.data.response.GetEvidencesResponse;
+import team.incude.gsmc.v2.domain.evidence.presentation.data.response.*;
 
 import java.util.UUID;
 
@@ -147,5 +144,10 @@ public class EvidenceWebAdapter {
     @GetMapping("/draft/reading/{draftId}")
     public ResponseEntity<GetDraftReadingEvidenceResponse> getDraftReading(@PathVariable UUID draftId) {
         return ResponseEntity.status(HttpStatus.OK).body(evidenceApplicationPort.findDraftReadingEvidenceByDraftId(draftId));
+    }
+
+    @GetMapping("/current/draft")
+    public ResponseEntity<GetDraftEvidenceResponse> getCurrentDraft() {
+        return ResponseEntity.status(HttpStatus.OK).body(evidenceApplicationPort.findDraftEvidenceByCurrentUser());
     }
 }

--- a/src/main/java/team/incude/gsmc/v2/domain/evidence/presentation/data/request/PatchStatusEvidenceRequest.java
+++ b/src/main/java/team/incude/gsmc/v2/domain/evidence/presentation/data/request/PatchStatusEvidenceRequest.java
@@ -1,9 +1,8 @@
 package team.incude.gsmc.v2.domain.evidence.presentation.data.request;
 
-import jakarta.validation.constraints.NotNull;
 import team.incude.gsmc.v2.domain.evidence.domain.constant.ReviewStatus;
 
 public record PatchStatusEvidenceRequest(
-        @NotNull ReviewStatus status
+        ReviewStatus status
 ) {
 }

--- a/src/main/java/team/incude/gsmc/v2/domain/evidence/presentation/data/request/PatchStatusEvidenceRequest.java
+++ b/src/main/java/team/incude/gsmc/v2/domain/evidence/presentation/data/request/PatchStatusEvidenceRequest.java
@@ -1,8 +1,9 @@
 package team.incude.gsmc.v2.domain.evidence.presentation.data.request;
 
+import jakarta.validation.constraints.NotNull;
 import team.incude.gsmc.v2.domain.evidence.domain.constant.ReviewStatus;
 
 public record PatchStatusEvidenceRequest(
-        ReviewStatus status
+        @NotNull ReviewStatus status
 ) {
 }

--- a/src/main/java/team/incude/gsmc/v2/domain/evidence/presentation/data/response/GetDraftEvidenceResponse.java
+++ b/src/main/java/team/incude/gsmc/v2/domain/evidence/presentation/data/response/GetDraftEvidenceResponse.java
@@ -1,0 +1,9 @@
+package team.incude.gsmc.v2.domain.evidence.presentation.data.response;
+
+import java.util.List;
+
+public record GetDraftEvidenceResponse(
+        List<GetDraftActivityEvidenceResponse> activityEvidences,
+        List<GetDraftReadingEvidenceResponse> readingEvidences
+) {
+}

--- a/src/test/java/team/incude/gsmc/v2/domain/evidence/application/usecase/service/CreateActivityEvidenceServiceTest.java
+++ b/src/test/java/team/incude/gsmc/v2/domain/evidence/application/usecase/service/CreateActivityEvidenceServiceTest.java
@@ -78,6 +78,7 @@ class CreateActivityEvidenceServiceTest {
 
                 Category category = Category.builder()
                         .name(categoryName)
+                        .maximumValue(6)
                         .build();
 
                 Score score = Score.builder()

--- a/src/test/java/team/incude/gsmc/v2/domain/evidence/application/usecase/service/CreateActivityEvidenceServiceTest.java
+++ b/src/test/java/team/incude/gsmc/v2/domain/evidence/application/usecase/service/CreateActivityEvidenceServiceTest.java
@@ -99,7 +99,7 @@ class CreateActivityEvidenceServiceTest {
                         .thenReturn(CompletableFuture.completedFuture("https://s3.com/fake.png"));
 
                 // when
-                createActivityEvidenceService.execute(categoryName, title, content, file, activityType);
+                createActivityEvidenceService.execute(categoryName, title, content, file, null, activityType, null);
 
                 // then
                 verify(scorePersistencePort).saveScore(any());

--- a/src/test/java/team/incude/gsmc/v2/domain/evidence/application/usecase/service/CreateOtherScoringEvidenceServiceTest.java
+++ b/src/test/java/team/incude/gsmc/v2/domain/evidence/application/usecase/service/CreateOtherScoringEvidenceServiceTest.java
@@ -18,6 +18,7 @@ import team.incude.gsmc.v2.domain.evidence.domain.OtherEvidence;
 import team.incude.gsmc.v2.domain.member.application.port.StudentDetailPersistencePort;
 import team.incude.gsmc.v2.domain.member.domain.Member;
 import team.incude.gsmc.v2.domain.member.domain.StudentDetail;
+import team.incude.gsmc.v2.domain.score.application.port.CategoryPersistencePort;
 import team.incude.gsmc.v2.domain.score.application.port.ScorePersistencePort;
 import team.incude.gsmc.v2.domain.score.domain.Category;
 import team.incude.gsmc.v2.domain.score.domain.Score;
@@ -51,6 +52,9 @@ public class CreateOtherScoringEvidenceServiceTest {
 
     @Mock
     private OtherEvidencePersistencePort otherEvidencePersistencePort;
+
+    @Mock
+    private CategoryPersistencePort categoryPersistencePort;
 
     @InjectMocks
     private CreateOtherScoringEvidenceService createOtherScoringEvidenceService;
@@ -87,7 +91,7 @@ public class CreateOtherScoringEvidenceServiceTest {
 
                 Category category = Category.builder()
                         .name(categoryName)
-                        .maximumValue(6)
+                        .maximumValue(1000)
                         .build();
 
                 Score score = Score.builder()
@@ -101,6 +105,8 @@ public class CreateOtherScoringEvidenceServiceTest {
                 when(scorePersistencePort.findScoreByCategoryNameAndStudentDetailStudentCodeWithLock(category.getName(), studentDetail.getStudentCode())).thenReturn(score);
                 when(s3Port.uploadFile(Mockito.anyString(), Mockito.any()))
                         .thenReturn(CompletableFuture.completedFuture(fakeFileUrl));
+                when(categoryPersistencePort.findCategoryByName(categoryName)).thenReturn(category);
+
                 // when
                 createOtherScoringEvidenceService.execute(categoryName, file, value);
 

--- a/src/test/java/team/incude/gsmc/v2/domain/evidence/application/usecase/service/CreateReadingEvidenceServiceTest.java
+++ b/src/test/java/team/incude/gsmc/v2/domain/evidence/application/usecase/service/CreateReadingEvidenceServiceTest.java
@@ -87,7 +87,7 @@ public class CreateReadingEvidenceServiceTest {
                 when(scorePersistencePort.findScoreByCategoryNameAndStudentDetailStudentCodeWithLock(category.getName(), studentDetail.getStudentCode())).thenReturn(score);
 
                 // when
-                createReadingEvidenceService.execute(title, author, page, content);
+                createReadingEvidenceService.execute(title, author, page, content, null);
 
                 // then
                 verify(scorePersistencePort).saveScore(any(Score.class));


### PR DESCRIPTION
## 📋 작업 내용
> 현재 인증된 사용자의 임시 저장 증빙자료를 모두 조회하는 서비스 클래스를 작성하였고 증빙자료 생성 서비스 클래스에서 score를 조회시 null인 경우 score를 생성하는 로직을 추가하였습니다

## 🤝 리뷰 시 참고사항
## ✅ 체크리스트
> 추가적으로 필요한 체크리스트가 있다면 추가적으로 작성해주세요.
- [x] 이 작업으로 인해 변경이 필요한 문서를 작성 또는 수정했나요? (e.g. `README`, `.env.example`)
- [x] 작업한 코드가 정상적으로 동작하는지 확인했나요?
- [ ] 작업한 코드에 대한 테스트 코드를 작성하거나 수정했나요?
- [x] Merge 대상 브랜치를 올바르게 설정했나요?
- [x] 해당 PR과 관련 없는 작업이 포함되지는 않았나요?
- [x] PR의 올바른 라벨과 리뷰어를 설정했나요?