### PR TITLE
한자/한국사 자격증 등록 시 동시성 문제 해결

### DIFF
--- a/src/main/java/team/incude/gsmc/v2/domain/certificate/application/port/CertificatePersistencePort.java
+++ b/src/main/java/team/incude/gsmc/v2/domain/certificate/application/port/CertificatePersistencePort.java
@@ -33,6 +33,13 @@ public interface CertificatePersistencePort {
     List<Certificate> findCertificateByStudentDetailStudentCode(String studentCode);
 
     /**
+     * 주어진 사용자 ID에 해당하는 자격증 목록을 조회하며 비관적 락(Pessimistic Lock)을 걸어 반환합니다.
+     * @param memberId 사용자의 고유 ID
+     * @return 해당 사용자가 소유한 자격증 목록
+     */
+    List<Certificate> findCertificateByMemberIdWithLock(Long memberId);
+
+    /**
      * 자격증 정보를 저장합니다.
      * <p>신규 자격증 등록뿐 아니라 수정된 자격증 정보를 반영할 때도 사용됩니다.
      * @param certificate 저장할 자격증 엔티티

--- a/src/main/java/team/incude/gsmc/v2/domain/certificate/application/usecase/service/CreateCertificateService.java
+++ b/src/main/java/team/incude/gsmc/v2/domain/certificate/application/usecase/service/CreateCertificateService.java
@@ -7,6 +7,7 @@ import org.springframework.web.multipart.MultipartFile;
 import team.incude.gsmc.v2.domain.certificate.application.port.CertificatePersistencePort;
 import team.incude.gsmc.v2.domain.certificate.application.usecase.CreateCertificateUseCase;
 import team.incude.gsmc.v2.domain.certificate.domain.Certificate;
+import team.incude.gsmc.v2.domain.certificate.exception.DuplicateCertificateException;
 import team.incude.gsmc.v2.domain.evidence.application.port.OtherEvidencePersistencePort;
 import team.incude.gsmc.v2.domain.evidence.application.port.S3Port;
 import team.incude.gsmc.v2.domain.evidence.domain.Evidence;
@@ -26,19 +27,14 @@ import team.incude.gsmc.v2.global.util.ValueLimiterUtil;
 import java.io.IOException;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.List;
 
 /**
- * 자격증 생성 유스케이스를 구현한 서비스 클래스입니다.
- * <p>{@link CreateCertificateUseCase}를 구현하며, 자격증 생성과 함께 관련 점수, 증빙 파일, 증거 객체를 생성하고 저장합니다.
- * <p>주요 처리 과정:
- * <ul>
- *   <li>카테고리 점수 확인 및 증가</li>
- *   <li>S3에 증빙 파일 업로드</li>
- *   <li>Evidence 및 OtherEvidence 생성</li>
- *   <li>자격증 저장</li>
- * </ul>
+ * 자격증 생성을 담당하는 유스케이스 구현체입니다.
+ * <p>
+ * 자격증 이름과 취득일, 파일 정보를 바탕으로 S3 업로드 및 점수 업데이트, 증빙 생성, 자격증 저장 등의 기능을 수행합니다.
+ * </p>
  *
- * <p>자격증 이름에 따라 자동으로 카테고리가 매핑되며, 점수 제한 초과 시 예외가 발생합니다.
  * @author snowykte0426
  */
 @Service
@@ -51,40 +47,39 @@ public class CreateCertificateService implements CreateCertificateUseCase {
     private final CategoryPersistencePort categoryPersistencePort;
     private final ScorePersistencePort scorePersistencePort;
     private final S3Port s3Port;
+    private final CurrentMemberProvider currentMemberProvider;
 
     private static final String MAJOR_CERTIFICATE_CATEGORY_NAME = "MAJOR-CERTIFICATE_NUM";
     private static final String HUMANITIES_CERTIFICATE_KOREAN_HISTORY_CATEGORY_NAME = "HUMANITIES-CERTIFICATE-KOREAN_HISTORY";
     private static final String HUMANITIES_CERTIFICATE_CHINESE_CHARACTER_CATEGORY_NAME = "HUMANITIES-CERTIFICATE-CHINESE_CHARACTER";
-    private final CurrentMemberProvider currentMemberProvider;
 
     /**
-     * 자격증을 생성합니다.
-     * <p>자격증 이름, 취득일, 증빙 파일을 받아 해당 정보를 기반으로 자격증을 생성하고 관련된 점수 및 증빙자료를 저장합니다.
-     * @param name 자격증 이름
+     * 자격증 생성을 수행합니다.
+     *
+     * @param name            자격증 이름
      * @param acquisitionDate 자격증 취득일
-     * @param file 자격증 증빙 파일
+     * @param file            자격증 증빙 파일
      */
     @Override
     public void execute(String name, LocalDate acquisitionDate, MultipartFile file) {
         Member member = currentMemberProvider.getCurrentUser();
-
+        validateDuplicateCertificateType(member, name);
         Score updatedScore = updateScore(member, name);
         Score savedScore = scorePersistencePort.saveScore(updatedScore);
-
         Evidence evidence = createEvidence(savedScore);
         String fileUri = uploadFileToS3(file);
         OtherEvidence otherEvidence = otherEvidencePersistencePort.saveOtherEvidence(createOtherEvidence(evidence, fileUri));
-
         saveCertificate(name, member, acquisitionDate, otherEvidence);
     }
 
     /**
-     * 자격증 이름에 따라 카테고리를 매핑하고 점수를 증가시킵니다.
-     * <p>점수가 존재하지 않으면 새로 생성하며, 최대 점수를 초과하는 경우 예외를 발생시킵니다.
-     * @param member 자격증을 등록하는 사용자
+     * 자격증 이름에 따라 점수를 업데이트합니다.
+     * 기존 점수가 존재하지 않으면 새로 생성합니다.
+     * 점수 제한을 초과하면 예외를 발생시킵니다.
+     *
+     * @param member          점수를 업데이트할 회원
      * @param certificateName 자격증 이름
-     * @return 업데이트된 점수 객체
-     * @throws ScoreLimitExceededException 최대 점수를 초과하는 경우
+     * @return 업데이트된 Score 객체
      */
     private Score updateScore(Member member, String certificateName) {
         String categoryName = resolveCategoryFromCertificateName(certificateName);
@@ -102,9 +97,10 @@ public class CreateCertificateService implements CreateCertificateUseCase {
     }
 
     /**
-     * 자격증 이름에 따라 카테고리 이름을 결정합니다.
+     * 자격증 이름으로부터 점수 카테고리를 판별합니다.
+     *
      * @param certificateName 자격증 이름
-     * @return 카테고리 이름
+     * @return 해당 이름에 대응하는 카테고리 이름
      */
     private String resolveCategoryFromCertificateName(String certificateName) {
         if (certificateName.startsWith("한국사 능력검정")) {
@@ -117,10 +113,11 @@ public class CreateCertificateService implements CreateCertificateUseCase {
     }
 
     /**
-     * 새 점수 객체를 생성합니다.
-     * @param category 카테고리
-     * @param member 사용자
-     * @return 생성된 점수 객체
+     * 새로운 점수 엔티티를 생성합니다.
+     *
+     * @param category 점수 카테고리
+     * @param member   대상 회원
+     * @return 생성된 Score 객체
      */
     private Score createNewScore(Category category, Member member) {
         return Score.builder()
@@ -131,8 +128,9 @@ public class CreateCertificateService implements CreateCertificateUseCase {
     }
 
     /**
-     * 점수를 기반으로 Evidence 객체를 생성합니다.
-     * @param score 점수
+     * 점수에 대한 증빙자료 엔티티를 생성합니다.
+     *
+     * @param score 점수 엔티티
      * @return 생성된 Evidence 객체
      */
     private Evidence createEvidence(Score score) {
@@ -146,10 +144,11 @@ public class CreateCertificateService implements CreateCertificateUseCase {
     }
 
     /**
-     * 증빙 파일을 S3에 업로드하고 URI를 반환합니다.
+     * 파일을 S3에 업로드하고 업로드된 파일의 URI를 반환합니다.
+     *
      * @param file 업로드할 파일
      * @return 업로드된 파일의 URI
-     * @throws S3UploadFailedException 업로드 실패 시
+     * @throws S3UploadFailedException 파일 업로드에 실패한 경우
      */
     private String uploadFileToS3(MultipartFile file) {
         try {
@@ -161,8 +160,9 @@ public class CreateCertificateService implements CreateCertificateUseCase {
 
     /**
      * Evidence와 파일 URI를 기반으로 OtherEvidence 객체를 생성합니다.
-     * @param evidence 증거 객체
-     * @param fileUri 파일 URI
+     *
+     * @param evidence 증빙 객체
+     * @param fileUri  S3에 업로드된 파일 URI
      * @return 생성된 OtherEvidence 객체
      */
     private OtherEvidence createOtherEvidence(Evidence evidence, String fileUri) {
@@ -174,10 +174,11 @@ public class CreateCertificateService implements CreateCertificateUseCase {
 
     /**
      * 자격증 정보를 저장합니다.
-     * @param name 자격증 이름
-     * @param member 사용자
+     *
+     * @param name            자격증 이름
+     * @param member          회원
      * @param acquisitionDate 자격증 취득일
-     * @param otherEvidence 연관 증빙 정보
+     * @param otherEvidence   증빙자료 정보
      */
     private void saveCertificate(String name, Member member, LocalDate acquisitionDate, OtherEvidence otherEvidence) {
         Certificate certificate = Certificate.builder()
@@ -187,5 +188,37 @@ public class CreateCertificateService implements CreateCertificateUseCase {
                 .acquisitionDate(acquisitionDate)
                 .build();
         certificatePersistencePort.saveCertificate(certificate);
+    }
+
+    /**
+     * 동일 계열 자격증의 중복 제출 여부를 확인합니다.
+     * 예: "한자검정시험(1)"이 존재하면 "한자검정시험(2)" 제출 차단
+     *
+     * @param member          회원
+     * @param certificateName 자격증 이름
+     * @throws DuplicateCertificateException 중복인 경우 예외 발생
+     */
+    private void validateDuplicateCertificateType(Member member, String certificateName) {
+        String typePrefix = resolveDuplicateRestrictedPrefix(certificateName);
+        if (typePrefix == null) return;
+        List<Certificate> lockedCertificates = certificatePersistencePort.findCertificateByMemberIdWithLock(member.getId());
+        boolean exists = lockedCertificates.stream()
+                .map(Certificate::getName)
+                .anyMatch(name -> name.startsWith(typePrefix));
+        if (exists) {
+            throw new DuplicateCertificateException();
+        }
+    }
+
+    /**
+     * 중복 검사를 위해 비교할 자격증 이름 접두사를 반환합니다.
+     *
+     * @param certificateName 자격증 이름
+     * @return 접두사 문자열 (중복 검사 대상이 아니면 null)
+     */
+    private String resolveDuplicateRestrictedPrefix(String certificateName) {
+        if (certificateName.startsWith("한국사 능력검정")) return "한국사 능력검정";
+        if (certificateName.startsWith("한자검정시험")) return "한자검정시험";
+        return null;
     }
 }

--- a/src/main/java/team/incude/gsmc/v2/domain/certificate/application/usecase/service/CreateCertificateService.java
+++ b/src/main/java/team/incude/gsmc/v2/domain/certificate/application/usecase/service/CreateCertificateService.java
@@ -34,7 +34,6 @@ import java.util.List;
  * <p>
  * 자격증 이름과 취득일, 파일 정보를 바탕으로 S3 업로드 및 점수 업데이트, 증빙 생성, 자격증 저장 등의 기능을 수행합니다.
  * </p>
- *
  * @author snowykte0426
  */
 @Service
@@ -55,7 +54,6 @@ public class CreateCertificateService implements CreateCertificateUseCase {
 
     /**
      * 자격증 생성을 수행합니다.
-     *
      * @param name            자격증 이름
      * @param acquisitionDate 자격증 취득일
      * @param file            자격증 증빙 파일
@@ -76,7 +74,6 @@ public class CreateCertificateService implements CreateCertificateUseCase {
      * 자격증 이름에 따라 점수를 업데이트합니다.
      * 기존 점수가 존재하지 않으면 새로 생성합니다.
      * 점수 제한을 초과하면 예외를 발생시킵니다.
-     *
      * @param member          점수를 업데이트할 회원
      * @param certificateName 자격증 이름
      * @return 업데이트된 Score 객체
@@ -98,7 +95,6 @@ public class CreateCertificateService implements CreateCertificateUseCase {
 
     /**
      * 자격증 이름으로부터 점수 카테고리를 판별합니다.
-     *
      * @param certificateName 자격증 이름
      * @return 해당 이름에 대응하는 카테고리 이름
      */
@@ -114,7 +110,6 @@ public class CreateCertificateService implements CreateCertificateUseCase {
 
     /**
      * 새로운 점수 엔티티를 생성합니다.
-     *
      * @param category 점수 카테고리
      * @param member   대상 회원
      * @return 생성된 Score 객체
@@ -129,7 +124,6 @@ public class CreateCertificateService implements CreateCertificateUseCase {
 
     /**
      * 점수에 대한 증빙자료 엔티티를 생성합니다.
-     *
      * @param score 점수 엔티티
      * @return 생성된 Evidence 객체
      */
@@ -145,7 +139,6 @@ public class CreateCertificateService implements CreateCertificateUseCase {
 
     /**
      * 파일을 S3에 업로드하고 업로드된 파일의 URI를 반환합니다.
-     *
      * @param file 업로드할 파일
      * @return 업로드된 파일의 URI
      * @throws S3UploadFailedException 파일 업로드에 실패한 경우
@@ -160,7 +153,6 @@ public class CreateCertificateService implements CreateCertificateUseCase {
 
     /**
      * Evidence와 파일 URI를 기반으로 OtherEvidence 객체를 생성합니다.
-     *
      * @param evidence 증빙 객체
      * @param fileUri  S3에 업로드된 파일 URI
      * @return 생성된 OtherEvidence 객체
@@ -174,7 +166,6 @@ public class CreateCertificateService implements CreateCertificateUseCase {
 
     /**
      * 자격증 정보를 저장합니다.
-     *
      * @param name            자격증 이름
      * @param member          회원
      * @param acquisitionDate 자격증 취득일
@@ -193,7 +184,6 @@ public class CreateCertificateService implements CreateCertificateUseCase {
     /**
      * 동일 계열 자격증의 중복 제출 여부를 확인합니다.
      * 예: "한자검정시험(1)"이 존재하면 "한자검정시험(2)" 제출 차단
-     *
      * @param member          회원
      * @param certificateName 자격증 이름
      * @throws DuplicateCertificateException 중복인 경우 예외 발생
@@ -212,7 +202,6 @@ public class CreateCertificateService implements CreateCertificateUseCase {
 
     /**
      * 중복 검사를 위해 비교할 자격증 이름 접두사를 반환합니다.
-     *
      * @param certificateName 자격증 이름
      * @return 접두사 문자열 (중복 검사 대상이 아니면 null)
      */

--- a/src/main/java/team/incude/gsmc/v2/domain/certificate/application/usecase/service/UpdateCurrentCertificateService.java
+++ b/src/main/java/team/incude/gsmc/v2/domain/certificate/application/usecase/service/UpdateCurrentCertificateService.java
@@ -7,6 +7,7 @@ import org.springframework.web.multipart.MultipartFile;
 import team.incude.gsmc.v2.domain.certificate.application.port.CertificatePersistencePort;
 import team.incude.gsmc.v2.domain.certificate.application.usecase.UpdateCurrentCertificateUseCase;
 import team.incude.gsmc.v2.domain.certificate.domain.Certificate;
+import team.incude.gsmc.v2.domain.certificate.exception.CertificateCategoryMismatchException;
 import team.incude.gsmc.v2.domain.certificate.exception.CertificateNotBelongToMemberException;
 import team.incude.gsmc.v2.domain.evidence.application.port.OtherEvidencePersistencePort;
 import team.incude.gsmc.v2.domain.evidence.application.port.S3Port;
@@ -34,6 +35,7 @@ import java.time.LocalDateTime;
  *   <li>자격증 정보 업데이트 및 저장</li>
  * </ul>
  * <p>변경 사항이 없을 경우 기존 값을 그대로 유지하며, 파일이 업로드되지 않은 경우 기존 Evidence를 재사용합니다.
+ *
  * @author snowykte0426
  */
 @Service
@@ -51,10 +53,10 @@ public class UpdateCurrentCertificateService implements UpdateCurrentCertificate
      * 자격증 정보를 업데이트합니다.
      * <p>현재 로그인한 사용자의 자격증을 찾아 이름, 취득일, 증빙 파일 등을 변경합니다.
      * 파일이 새로 업로드된 경우 S3에서 기존 파일을 삭제하고 새 파일을 업로드합니다.
-     * @param certificateId 수정할 자격증의 ID
-     * @param name 변경할 자격증 이름 (null 허용)
+     * @param certificateId   수정할 자격증의 ID
+     * @param name            변경할 자격증 이름 (null 허용)
      * @param acquisitionDate 변경할 자격증 취득일 (null 허용)
-     * @param file 교체할 자격증 파일 (null 허용)
+     * @param file            교체할 자격증 파일 (null 허용)
      * @throws CertificateNotBelongToMemberException 자격증이 현재 사용자 소유가 아닐 경우
      */
     @Override
@@ -62,7 +64,7 @@ public class UpdateCurrentCertificateService implements UpdateCurrentCertificate
         Member member = memberPersistencePort.findMemberByEmail(currentMemberProvider.getCurrentUser().getEmail());
 
         Certificate existingCertificate = certificatePersistencePort.findCertificateByIdWithLock(certificateId);
-
+        validateCategoryChange(existingCertificate.getName(), name);
         OtherEvidence existingOtherEvidence = existingCertificate.getEvidence();
         String existingFileUri = existingOtherEvidence.getFileUri();
         Evidence evidence = existingOtherEvidence.getId();
@@ -103,6 +105,28 @@ public class UpdateCurrentCertificateService implements UpdateCurrentCertificate
                 .build();
 
         certificatePersistencePort.saveCertificate(updatedCertificate);
+    }
+
+    /**
+     * 자격증 이름 변경 시 한자 및 한국사 카테고리의 일관성을 검증합니다.
+     * <p>예를 들어, 일반 자격증을 한자/한국사 자격증으로 변경하거나 그 반대의 경우 예외를 발생시킵니다.
+     * <p>단, 동일한 카테고리 내에서 세부 등급 변경(예: 1급 → 2급)은 허용됩니다.
+     * @param originalName 기존 자격증 이름
+     * @param newName      새 자격증 이름 (null 가능)
+     * @throws CertificateCategoryMismatchException 유효하지 않은 카테고리 변경 시 발생
+     */
+    private void validateCategoryChange(String originalName, String newName) {
+        boolean isOriginalHanja = originalName != null && originalName.startsWith("한자검정시험");
+        boolean isOriginalHistory = originalName != null && originalName.startsWith("한국사 능력검정");
+        boolean isNewHanja = newName != null && newName.startsWith("한자검정시험");
+        boolean isNewHistory = newName != null && newName.startsWith("한국사 능력검정");
+
+        if ((isOriginalHanja && !isNewHanja) ||
+            (!isOriginalHanja && isNewHanja) ||
+            (isOriginalHistory && !isNewHistory) ||
+            (!isOriginalHistory && isNewHistory)) {
+            throw new CertificateCategoryMismatchException();
+        }
     }
 
     /**

--- a/src/main/java/team/incude/gsmc/v2/domain/certificate/exception/CertificateCategoryMismatchException.java
+++ b/src/main/java/team/incude/gsmc/v2/domain/certificate/exception/CertificateCategoryMismatchException.java
@@ -1,0 +1,10 @@
+package team.incude.gsmc.v2.domain.certificate.exception;
+
+import team.incude.gsmc.v2.global.error.ErrorCode;
+import team.incude.gsmc.v2.global.error.exception.GsmcException;
+
+public class CertificateCategoryMismatchException extends GsmcException {
+    public CertificateCategoryMismatchException() {
+        super(ErrorCode.CERTIFICATE_CATEGORY_MISMATCH);
+    }
+}

--- a/src/main/java/team/incude/gsmc/v2/domain/certificate/exception/DuplicateCertificateException.java
+++ b/src/main/java/team/incude/gsmc/v2/domain/certificate/exception/DuplicateCertificateException.java
@@ -1,0 +1,10 @@
+package team.incude.gsmc.v2.domain.certificate.exception;
+
+import team.incude.gsmc.v2.global.error.ErrorCode;
+import team.incude.gsmc.v2.global.error.exception.GsmcException;
+
+public class DuplicateCertificateException extends GsmcException {
+    public DuplicateCertificateException() {
+        super(ErrorCode.DUPLICATE_CERTIFICATE);
+    }
+}

--- a/src/main/java/team/incude/gsmc/v2/domain/certificate/persistence/CertificatePersistenceAdapter.java
+++ b/src/main/java/team/incude/gsmc/v2/domain/certificate/persistence/CertificatePersistenceAdapter.java
@@ -85,6 +85,18 @@ public class CertificatePersistenceAdapter implements CertificatePersistencePort
                 .toList();
     }
 
+    @Override
+    public List<Certificate> findCertificateByMemberIdWithLock(Long memberId) {
+        return jpaQueryFactory
+                .selectFrom(certificateJpaEntity)
+                .setLockMode(LockModeType.PESSIMISTIC_WRITE)
+                .where(certificateJpaEntity.member.id.eq(memberId))
+                .fetch()
+                .stream()
+                .map(certificateMapper::toDomain)
+                .toList();
+    }
+
     /**
      * 자격증 도메인 객체를 저장합니다.
      * @param certificate 저장할 자격증 도메인 객체

--- a/src/main/java/team/incude/gsmc/v2/global/error/ErrorCode.java
+++ b/src/main/java/team/incude/gsmc/v2/global/error/ErrorCode.java
@@ -34,6 +34,7 @@ public enum ErrorCode {
     // Certificate
     CERTIFICATE_NOT_FOUND("Certificate Not Found", HttpStatus.NOT_FOUND.value()),
     CERTIFICATE_NOT_BELONG_TO_MEMBER("Certificate Not Belong To Member", HttpStatus.FORBIDDEN.value()),
+    DUPLICATE_CERTIFICATE("Duplicate Certificate", HttpStatus.CONFLICT.value()),
 
     // Score
     SCORE_MAXIMUM_VALUE_EXCEEDED("Score Maximum Value Exceeded", HttpStatus.UNPROCESSABLE_ENTITY.value()),

--- a/src/main/java/team/incude/gsmc/v2/global/error/ErrorCode.java
+++ b/src/main/java/team/incude/gsmc/v2/global/error/ErrorCode.java
@@ -35,6 +35,7 @@ public enum ErrorCode {
     CERTIFICATE_NOT_FOUND("Certificate Not Found", HttpStatus.NOT_FOUND.value()),
     CERTIFICATE_NOT_BELONG_TO_MEMBER("Certificate Not Belong To Member", HttpStatus.FORBIDDEN.value()),
     DUPLICATE_CERTIFICATE("Duplicate Certificate", HttpStatus.CONFLICT.value()),
+    CERTIFICATE_CATEGORY_MISMATCH("Certificate Category Mismatch", HttpStatus.UNPROCESSABLE_ENTITY.value()),
 
     // Score
     SCORE_MAXIMUM_VALUE_EXCEEDED("Score Maximum Value Exceeded", HttpStatus.UNPROCESSABLE_ENTITY.value()),


### PR DESCRIPTION
## 📋 작업 내용
> #89 를 해결하기 위하여 비관적 락을 강화하였으며 검증 로직을 강화하였습니다.또한 자격증 정보 수정 비즈니스 로직에서도 검증을 강화하였습니다

## 🤝 리뷰 시 참고사항
> 
## ✅ 체크리스트
- [x] 이 작업으로 인해 변경이 필요한 문서를 작성 또는 수정했나요? (e.g. `README`, `.env.example`)
- [x] 작업한 코드가 정상적으로 동작하는지 확인했나요?
- [x] 작업한 코드에 대한 테스트 코드를 작성하거나 수정했나요?
- [x] Merge 대상 브랜치를 올바르게 설정했나요?
- [x] 해당 PR과 관련 없는 작업이 포함되지는 않았나요?
- [x] PR의 올바른 라벨과 리뷰어를 설정했나요?