### PR TITLE
자격증 변동 시 종합 점수 계산 이벤트 발행 추가

### DIFF
--- a/src/main/java/team/incude/gsmc/v2/domain/certificate/application/usecase/service/DeleteCertificateService.java
+++ b/src/main/java/team/incude/gsmc/v2/domain/certificate/application/usecase/service/DeleteCertificateService.java
@@ -1,6 +1,7 @@
 package team.incude.gsmc.v2.domain.certificate.application.usecase.service;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationContext;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import team.incude.gsmc.v2.domain.certificate.application.port.CertificatePersistencePort;
@@ -16,6 +17,7 @@ import team.incude.gsmc.v2.domain.member.domain.Member;
 import team.incude.gsmc.v2.domain.score.application.port.ScorePersistencePort;
 import team.incude.gsmc.v2.domain.score.domain.Score;
 import team.incude.gsmc.v2.domain.score.exception.InvalidScoreValueException;
+import team.incude.gsmc.v2.global.event.ScoreUpdatedEvent;
 import team.incude.gsmc.v2.global.security.jwt.usecase.service.CurrentMemberProvider;
 import team.incude.gsmc.v2.global.util.ExtractFileKeyUtil;
 
@@ -43,6 +45,7 @@ public class DeleteCertificateService implements DeleteCertificateUseCase {
     private final MemberPersistencePort memberPersistencePort;
     private final S3Port s3Port;
     private final CurrentMemberProvider currentMemberProvider;
+    private final ApplicationContext applicationContext;
 
     private static final String CATEGORY_NAME = "MAJOR-CERTIFICATE_NUM";
     private static final String HUMANITIES_CERTIFICATE_KOREAN_HISTORY_CATEGORY_NAME = "HUMANITIES-CERTIFICATE-KOREAN_HISTORY";
@@ -66,6 +69,7 @@ public class DeleteCertificateService implements DeleteCertificateUseCase {
     public void execute(String studentCode, Long id) {
         Member member = memberPersistencePort.findMemberByStudentDetailStudentCode(studentCode);
         deleteCertificate(member, id);
+        applicationContext.publishEvent(new ScoreUpdatedEvent(studentCode));
     }
 
     /**


### PR DESCRIPTION
## 📋 작업 내용
> 자격증 신규 등록 또는 삭제 시 종합점수를 다시 계산하도록 이벤트를 발행하도록 기능을 추가하였습니다

## 🤝 리뷰 시 참고사항
> #93 지난 Pull Request에 해결되었어야 하는 사항이였는데 그때 미처 생각하지 못했습니다,죄송합니다😅

## ✅ 체크리스트
- [x] 이 작업으로 인해 변경이 필요한 문서를 작성 또는 수정했나요? (e.g. `README`, `.env.example`)
- [x] 작업한 코드가 정상적으로 동작하는지 확인했나요?
- [x] 작업한 코드에 대한 테스트 코드를 작성하거나 수정했나요?
- [x] Merge 대상 브랜치를 올바르게 설정했나요?
- [x] 해당 PR과 관련 없는 작업이 포함되지는 않았나요?
- [x] PR의 올바른 라벨과 리뷰어를 설정했나요?