### PR TITLE
대기상태 증빙자료 여부 포함 사용자 조회 시 다건 조회 문제 수정

### DIFF
--- a/src/main/java/team/incude/gsmc/v2/domain/member/persistence/StudentDetailPersistenceAdapter.java
+++ b/src/main/java/team/incude/gsmc/v2/domain/member/persistence/StudentDetailPersistenceAdapter.java
@@ -1,6 +1,7 @@
 package team.incude.gsmc.v2.domain.member.persistence;
 
 import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.LockModeType;
 import lombok.RequiredArgsConstructor;
@@ -167,13 +168,14 @@ public class StudentDetailPersistenceAdapter implements StudentDetailPersistence
                                         studentDetailJpaEntity.classNumber,
                                         studentDetailJpaEntity.number,
                                         studentDetailJpaEntity.totalScore,
-                                        evidenceJpaEntity.id.isNotNull(),
+                                        JPAExpressions.selectOne()
+                                                .from(evidenceJpaEntity)
+                                                .where(evidenceJpaEntity.score.member.id.eq(studentDetailJpaEntity.member.id))
+                                                .exists(),
                                         studentDetailJpaEntity.member.role
                                 )
                         )
                         .from(studentDetailJpaEntity)
-                        .leftJoin(evidenceJpaEntity)
-                        .on(evidenceJpaEntity.score.member.id.eq(studentDetailJpaEntity.member.id))
                         .where(studentDetailJpaEntity.member.email.eq(email))
                         .fetchOne()
         ).map(studentDetailMapper::fromProjection).orElseThrow(MemberNotFoundException::new);


### PR DESCRIPTION
## 📋 작업 내용
> 기존 단순 ``JOIN``을 통하여 대기 상태 증빙자료의 여부를 포함한 사용자 정보를 조회할 때 단건 결과를 기대였지만 다건이 조회되며 Hibernates에서 예외를 발행,해당 API의 사용이 불가해지는 문제를 서브쿼리를 통하여 단건 조회를 보장하게 하여 수정하였습니다

## 🤝 리뷰 시 참고사항
> 문제가 발생하는 엔드포인트를 정확히 클라이언트 팀에서 전달받지 못하여 일단 문제가 발생하는 것으로 보이는 부분을 수정하였습니다

## ✅ 체크리스트
- [x] 이 작업으로 인해 변경이 필요한 문서를 작성 또는 수정했나요? (e.g. `README`, `.env.example`)
- [x] 작업한 코드가 정상적으로 동작하는지 확인했나요?
- [x] 작업한 코드에 대한 테스트 코드를 작성하거나 수정했나요?
- [x] Merge 대상 브랜치를 올바르게 설정했나요?
- [x] 해당 PR과 관련 없는 작업이 포함되지는 않았나요?
- [x] PR의 올바른 라벨과 리뷰어를 설정했나요?