### PR TITLE
인증제 항목 캐싱 개선

### DIFF
--- a/src/main/java/team/incude/gsmc/v2/domain/evidence/application/usecase/service/CreateActivityEvidenceService.java
+++ b/src/main/java/team/incude/gsmc/v2/domain/evidence/application/usecase/service/CreateActivityEvidenceService.java
@@ -19,6 +19,7 @@ import team.incude.gsmc.v2.domain.score.application.port.CategoryPersistencePort
 import team.incude.gsmc.v2.domain.score.application.port.ScorePersistencePort;
 import team.incude.gsmc.v2.domain.score.domain.Category;
 import team.incude.gsmc.v2.domain.score.domain.Score;
+import team.incude.gsmc.v2.domain.score.exception.CategoryNotFoundException;
 import team.incude.gsmc.v2.domain.score.exception.ScoreLimitExceededException;
 import team.incude.gsmc.v2.global.event.DraftEvidenceDeleteEvent;
 import team.incude.gsmc.v2.global.event.ScoreUpdatedEvent;
@@ -155,7 +156,11 @@ public class CreateActivityEvidenceService implements CreateActivityEvidenceUseC
      * @return 생성된 Score 객체
      */
     private Score createScore(String categoryName, Member member) {
-        Category category = categoryPersistencePort.findCategoryByName(categoryName);
+        Category category = categoryPersistencePort.findAllCategory()
+                .stream()
+                .filter(cat -> cat.getName().equals(categoryName))
+                .findFirst()
+                .orElseThrow(CategoryNotFoundException::new);
         return Score.builder()
                 .category(category)
                 .value(0)

--- a/src/main/java/team/incude/gsmc/v2/domain/evidence/application/usecase/service/CreateOtherEvidenceService.java
+++ b/src/main/java/team/incude/gsmc/v2/domain/evidence/application/usecase/service/CreateOtherEvidenceService.java
@@ -19,6 +19,7 @@ import team.incude.gsmc.v2.domain.score.application.port.CategoryPersistencePort
 import team.incude.gsmc.v2.domain.score.application.port.ScorePersistencePort;
 import team.incude.gsmc.v2.domain.score.domain.Category;
 import team.incude.gsmc.v2.domain.score.domain.Score;
+import team.incude.gsmc.v2.domain.score.exception.CategoryNotFoundException;
 import team.incude.gsmc.v2.domain.score.exception.ScoreLimitExceededException;
 import team.incude.gsmc.v2.global.event.ScoreUpdatedEvent;
 import team.incude.gsmc.v2.global.security.jwt.application.usecase.service.CurrentMemberProvider;
@@ -136,7 +137,11 @@ public class CreateOtherEvidenceService implements CreateOtherEvidenceUseCase {
      * @return 생성된 Score 객체
      */
     private Score createScore(String categoryName, Member member) {
-        Category category = categoryPersistencePort.findCategoryByName(categoryName);
+        Category category = categoryPersistencePort.findAllCategory()
+                .stream()
+                .filter(cat -> cat.getName().equals(categoryName))
+                .findFirst()
+                .orElseThrow(CategoryNotFoundException::new);
         return Score.builder()
                 .category(category)
                 .value(0)

--- a/src/main/java/team/incude/gsmc/v2/domain/evidence/application/usecase/service/CreateOtherScoringEvidenceService.java
+++ b/src/main/java/team/incude/gsmc/v2/domain/evidence/application/usecase/service/CreateOtherScoringEvidenceService.java
@@ -19,6 +19,7 @@ import team.incude.gsmc.v2.domain.score.application.port.CategoryPersistencePort
 import team.incude.gsmc.v2.domain.score.application.port.ScorePersistencePort;
 import team.incude.gsmc.v2.domain.score.domain.Category;
 import team.incude.gsmc.v2.domain.score.domain.Score;
+import team.incude.gsmc.v2.domain.score.exception.CategoryNotFoundException;
 import team.incude.gsmc.v2.domain.score.exception.ScoreLimitExceededException;
 import team.incude.gsmc.v2.global.event.ScoreUpdatedEvent;
 import team.incude.gsmc.v2.global.security.jwt.application.usecase.service.CurrentMemberProvider;
@@ -67,7 +68,11 @@ public class CreateOtherScoringEvidenceService implements CreateOtherScoringEvid
         Member member = currentMemberProvider.getCurrentUser();
         StudentDetail studentDetail = studentDetailPersistencePort.findStudentDetailByMemberEmail(member.getEmail());
         Score score = scorePersistencePort.findScoreByCategoryNameAndStudentDetailStudentCodeWithLock(categoryName, studentDetail.getStudentCode());
-        Category category = categoryPersistencePort.findCategoryByName(categoryName);
+        Category category = categoryPersistencePort.findAllCategory()
+                .stream()
+                .filter(cat -> cat.getName().equals(categoryName))
+                .findFirst()
+                .orElseThrow(CategoryNotFoundException::new);
         checkValueByMaximumValue(category, value);
 
         if (score == null) {

--- a/src/main/java/team/incude/gsmc/v2/domain/evidence/application/usecase/service/CreateReadingEvidenceService.java
+++ b/src/main/java/team/incude/gsmc/v2/domain/evidence/application/usecase/service/CreateReadingEvidenceService.java
@@ -17,6 +17,7 @@ import team.incude.gsmc.v2.domain.score.application.port.CategoryPersistencePort
 import team.incude.gsmc.v2.domain.score.application.port.ScorePersistencePort;
 import team.incude.gsmc.v2.domain.score.domain.Category;
 import team.incude.gsmc.v2.domain.score.domain.Score;
+import team.incude.gsmc.v2.domain.score.exception.CategoryNotFoundException;
 import team.incude.gsmc.v2.domain.score.exception.ScoreLimitExceededException;
 import team.incude.gsmc.v2.global.event.DraftEvidenceDeleteEvent;
 import team.incude.gsmc.v2.global.event.ScoreUpdatedEvent;
@@ -88,7 +89,11 @@ public class CreateReadingEvidenceService implements CreateReadingEvidenceUseCas
      * @return 생성된 Score 객체
      */
     private Score createScore(Member member) {
-        Category category = categoryPersistencePort.findCategoryByName(HUMANITIES_READING);
+        Category category = categoryPersistencePort.findAllCategory()
+                .stream()
+                .filter(cat -> cat.getName().equals(HUMANITIES_READING))
+                .findFirst()
+                .orElseThrow(CategoryNotFoundException::new);
         return Score.builder()
                 .category(category)
                 .value(0)

--- a/src/main/java/team/incude/gsmc/v2/domain/evidence/presentation/EvidenceWebAdapter.java
+++ b/src/main/java/team/incude/gsmc/v2/domain/evidence/presentation/EvidenceWebAdapter.java
@@ -229,7 +229,7 @@ public class EvidenceWebAdapter {
      * @return 생성된 임시저장 정보
      */
     @PostMapping("/current/draft/reading")
-    public ResponseEntity<CreateDraftEvidenceResponse> createDraftReading(@Valid @RequestBody CreateReadingEvidenceRequest reqeust) {
+    public ResponseEntity<CreateDraftEvidenceResponse> createDraftReading(@RequestBody CreateReadingEvidenceRequest reqeust) {
         return ResponseEntity.status(HttpStatus.CREATED).body(evidenceApplicationPort.createDraftReadingEvidence(
                 reqeust.draftId(), reqeust.title(), reqeust.author(), reqeust.page(), reqeust.content()));
     }

--- a/src/main/java/team/incude/gsmc/v2/domain/evidence/presentation/data/request/CreateDraftActivityEvidenceReqeust.java
+++ b/src/main/java/team/incude/gsmc/v2/domain/evidence/presentation/data/request/CreateDraftActivityEvidenceReqeust.java
@@ -23,9 +23,9 @@ import java.util.UUID;
  */
 public record CreateDraftActivityEvidenceReqeust(
         UUID draftId,
-        @NotNull String categoryName,
-        @NotNull String title,
-        @NotNull String content,
+        String categoryName,
+        String title,
+        String content,
         MultipartFile file,
         String imageUrl,
         @NotNull EvidenceType activityType

--- a/src/main/java/team/incude/gsmc/v2/domain/evidence/presentation/data/request/CreateDraftReadingEvidenceRequest.java
+++ b/src/main/java/team/incude/gsmc/v2/domain/evidence/presentation/data/request/CreateDraftReadingEvidenceRequest.java
@@ -18,9 +18,9 @@ import java.util.UUID;
  */
 public record CreateDraftReadingEvidenceRequest(
         UUID draftId,
-        @NotNull String title,
-        @NotNull String author,
-        @NotNull Integer page,
-        @NotNull String content
+        String title,
+        String author,
+        Integer page,
+        String content
 ) {
 }

--- a/src/main/java/team/incude/gsmc/v2/domain/score/application/usecase/service/UpdateScoreService.java
+++ b/src/main/java/team/incude/gsmc/v2/domain/score/application/usecase/service/UpdateScoreService.java
@@ -12,6 +12,7 @@ import team.incude.gsmc.v2.domain.score.application.port.ScorePersistencePort;
 import team.incude.gsmc.v2.domain.score.application.usecase.UpdateScoreUseCase;
 import team.incude.gsmc.v2.domain.score.domain.Category;
 import team.incude.gsmc.v2.domain.score.domain.Score;
+import team.incude.gsmc.v2.domain.score.exception.CategoryNotFoundException;
 import team.incude.gsmc.v2.domain.score.exception.RequiredEvidenceCategoryException;
 import team.incude.gsmc.v2.domain.score.exception.ScoreLimitExceededException;
 import team.incude.gsmc.v2.global.event.ScoreUpdatedEvent;
@@ -78,7 +79,11 @@ public class UpdateScoreService implements UpdateScoreUseCase {
      * @throws RequiredEvidenceCategoryException 증빙이 필요한 카테고리인 경우
      */
     protected void updateScore(String studentCode, String categoryName, Integer value) {
-        Category category = categoryPersistencePort.findCategoryByName(categoryName);
+        Category category = categoryPersistencePort.findAllCategory()
+                .stream()
+                .filter(cat -> cat.getName().equals(categoryName))
+                .findFirst()
+                .orElseThrow(CategoryNotFoundException::new);
         if (ValueLimiterUtil.isExceedingLimit(value, category.getMaximumValue())) {
             throw new ScoreLimitExceededException();
         }

--- a/src/main/java/team/incude/gsmc/v2/domain/score/persistence/CategoryPersistenceAdapter.java
+++ b/src/main/java/team/incude/gsmc/v2/domain/score/persistence/CategoryPersistenceAdapter.java
@@ -42,7 +42,6 @@ public class CategoryPersistenceAdapter implements CategoryPersistencePort {
      * @return 도메인 카테고리 객체
      * @throws CategoryNotFoundException 카테고리를 찾을 수 없는 경우
      */
-    @Cacheable(value = "category", key = "#name")
     @Override
     public Category findCategoryByName(String name) {
         return Optional.ofNullable(
@@ -57,6 +56,7 @@ public class CategoryPersistenceAdapter implements CategoryPersistencePort {
      * 모든 카테고리 목록을 조회합니다.
      * @return 도메인 카테고리 객체 리스트
      */
+    @Cacheable(value = "categories", key = "#name")
     @Override
     public List<Category> findAllCategory() {
         return categoryJpaRepository.findAll().stream().map(categoryMapper::toDomain).toList();

--- a/src/main/java/team/incude/gsmc/v2/global/config/CacheConfig.java
+++ b/src/main/java/team/incude/gsmc/v2/global/config/CacheConfig.java
@@ -28,7 +28,7 @@ public class CacheConfig {
 
     @Bean
     public CaffeineCacheManager cacheManager() {
-        CaffeineCacheManager caffeineCacheManager = new CaffeineCacheManager("category");
+        CaffeineCacheManager caffeineCacheManager = new CaffeineCacheManager("categories");
         caffeineCacheManager.setCaffeine(
                 Caffeine.newBuilder()
                         .expireAfterWrite(expireAfterWrite, TimeUnit.MINUTES)

--- a/src/main/java/team/incude/gsmc/v2/global/event/handler/DraftEvidenceDeleteEventListener.java
+++ b/src/main/java/team/incude/gsmc/v2/global/event/handler/DraftEvidenceDeleteEventListener.java
@@ -1,6 +1,7 @@
 package team.incude.gsmc.v2.global.event.handler;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
@@ -9,6 +10,7 @@ import team.incude.gsmc.v2.domain.evidence.application.port.DraftReadingEvidence
 import team.incude.gsmc.v2.global.event.DraftEvidenceDeleteEvent;
 
 @Component
+@Slf4j
 @RequiredArgsConstructor
 public class DraftEvidenceDeleteEventListener {
 
@@ -18,7 +20,16 @@ public class DraftEvidenceDeleteEventListener {
     @Async
     @EventListener(DraftEvidenceDeleteEvent.class)
     public void handleDraftEvidenceDeleteEvent(DraftEvidenceDeleteEvent event) {
-        activityEvidencePersistencePort.deleteDraftActivityEvidenceById(event.draftId());
-        readingEvidencePersistencePort.deleteDraftReadingEvidenceById(event.draftId());
+        try {
+            activityEvidencePersistencePort.deleteDraftActivityEvidenceById(event.draftId());
+        } catch (Exception e) {
+            log.debug("Failed to delete draft activity evidence. draftId: {}, error: {}", event.draftId(), e.getMessage());
+        }
+
+        try {
+            readingEvidencePersistencePort.deleteDraftReadingEvidenceById(event.draftId());
+        } catch (Exception e) {
+            log.debug("Failed to delete draft reading evidence. draftId: {}, error: {}", event.draftId(), e.getMessage());
+        }
     }
 }

--- a/src/test/java/team/incude/gsmc/v2/domain/evidence/application/usecase/service/CreateActivityEvidenceServiceTest.java
+++ b/src/test/java/team/incude/gsmc/v2/domain/evidence/application/usecase/service/CreateActivityEvidenceServiceTest.java
@@ -21,6 +21,7 @@ import team.incude.gsmc.v2.domain.score.domain.Score;
 import team.incude.gsmc.v2.global.event.ScoreUpdatedEvent;
 import team.incude.gsmc.v2.global.security.jwt.application.usecase.service.CurrentMemberProvider;
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.util.concurrent.CompletableFuture;
 
@@ -55,36 +56,30 @@ class CreateActivityEvidenceServiceTest {
 
             @Test
             @DisplayName("활동 증빙을 생성한다.")
-            void it_creates_activity_evidence() throws Exception {
+            void it_creates_activity_evidence() throws IOException {
                 // given
                 String categoryName = "동아리활동";
                 String title = "백엔드 세미나";
                 String content = "JPA 소개 세션 진행";
                 EvidenceType activityType = EvidenceType.MAJOR;
-
                 StudentDetail studentDetail = StudentDetail.builder()
                         .studentCode("24035")
                         .build();
-
                 Member member = Member.builder()
                         .email("test@example.com")
                         .build();
-
                 Category category = Category.builder()
                         .name(categoryName)
                         .maximumValue(6)
                         .build();
-
                 Score score = Score.builder()
                         .id(1L)
                         .member(member)
                         .category(category)
                         .value(0)
                         .build();
-
                 MultipartFile file = mock(MultipartFile.class);
                 InputStream fakeInputStream = mock(InputStream.class);
-
                 when(currentMemberProvider.getCurrentUser()).thenReturn(member);
                 when(scorePersistencePort.findScoreByCategoryNameAndStudentDetailStudentCodeWithLock(categoryName, studentDetail.getStudentCode())).thenReturn(score);
                 when(studentDetailPersistencePort.findStudentDetailByMemberEmail(member.getEmail()))

--- a/src/test/java/team/incude/gsmc/v2/domain/evidence/application/usecase/service/CreateActivityEvidenceServiceTest.java
+++ b/src/test/java/team/incude/gsmc/v2/domain/evidence/application/usecase/service/CreateActivityEvidenceServiceTest.java
@@ -32,22 +32,16 @@ class CreateActivityEvidenceServiceTest {
 
     @Mock
     private StudentDetailPersistencePort studentDetailPersistencePort;
-
     @Mock
     private ActivityEvidencePersistencePort activityEvidencePersistencePort;
-
     @Mock
     private ScorePersistencePort scorePersistencePort;
-
     @Mock
     private S3Port s3Port;
-
     @Mock
     private CurrentMemberProvider currentMemberProvider;
-
     @Mock
     private ApplicationEventPublisher applicationEventPublisher;
-
     @InjectMocks
     private CreateActivityEvidenceService createActivityEvidenceService;
 

--- a/src/test/java/team/incude/gsmc/v2/domain/evidence/application/usecase/service/CreateActivityEvidenceServiceTest.java
+++ b/src/test/java/team/incude/gsmc/v2/domain/evidence/application/usecase/service/CreateActivityEvidenceServiceTest.java
@@ -104,7 +104,7 @@ class CreateActivityEvidenceServiceTest {
 
                 // then
                 verify(scorePersistencePort).saveScore(any());
-                verify(activityEvidencePersistencePort).saveActivityEvidence(any());
+                verify(activityEvidencePersistencePort).saveActivityEvidence(any(), any());
                 verify(applicationEventPublisher).publishEvent(argThat((Object event) ->
                         event instanceof ScoreUpdatedEvent &&
                                 ((ScoreUpdatedEvent) event).studentCode().equals(studentDetail.getStudentCode())

--- a/src/test/java/team/incude/gsmc/v2/domain/evidence/application/usecase/service/CreateOtherEvidenceServiceTest.java
+++ b/src/test/java/team/incude/gsmc/v2/domain/evidence/application/usecase/service/CreateOtherEvidenceServiceTest.java
@@ -105,7 +105,7 @@ public class CreateOtherEvidenceServiceTest {
                 // then
                 verify(scorePersistencePort).saveScore(Mockito.any(Score.class));
                 verify(scorePersistencePort).saveScore(argThat(savedScore -> savedScore.getValue() == 3));
-                verify(otherEvidencePersistencePort).saveOtherEvidence(Mockito.any(OtherEvidence.class));
+                verify(otherEvidencePersistencePort).saveOtherEvidence(any(), Mockito.any(OtherEvidence.class));
                 verify(applicationEventPublisher).publishEvent(argThat((Object event) ->
                         event instanceof ScoreUpdatedEvent &&
                                 ((ScoreUpdatedEvent) event).studentCode().equals(studentDetail.getStudentCode())

--- a/src/test/java/team/incude/gsmc/v2/domain/evidence/application/usecase/service/CreateOtherScoringEvidenceServiceTest.java
+++ b/src/test/java/team/incude/gsmc/v2/domain/evidence/application/usecase/service/CreateOtherScoringEvidenceServiceTest.java
@@ -26,6 +26,7 @@ import team.incude.gsmc.v2.global.event.ScoreUpdatedEvent;
 import team.incude.gsmc.v2.global.security.jwt.application.usecase.service.CurrentMemberProvider;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -105,7 +106,7 @@ public class CreateOtherScoringEvidenceServiceTest {
                 when(scorePersistencePort.findScoreByCategoryNameAndStudentDetailStudentCodeWithLock(category.getName(), studentDetail.getStudentCode())).thenReturn(score);
                 when(s3Port.uploadFile(Mockito.anyString(), Mockito.any()))
                         .thenReturn(CompletableFuture.completedFuture(fakeFileUrl));
-                when(categoryPersistencePort.findCategoryByName(categoryName)).thenReturn(category);
+                when(categoryPersistencePort.findAllCategory()).thenReturn(List.of(category));
 
                 // when
                 createOtherScoringEvidenceService.execute(categoryName, file, value);

--- a/src/test/java/team/incude/gsmc/v2/domain/evidence/application/usecase/service/CreateOtherScoringEvidenceServiceTest.java
+++ b/src/test/java/team/incude/gsmc/v2/domain/evidence/application/usecase/service/CreateOtherScoringEvidenceServiceTest.java
@@ -112,7 +112,7 @@ public class CreateOtherScoringEvidenceServiceTest {
 
                 // then
                 verify(scorePersistencePort).saveScore(any(Score.class));
-                verify(otherEvidencePersistencePort).saveOtherEvidence(any(OtherEvidence.class));
+                verify(otherEvidencePersistencePort).saveOtherEvidence(any(), any(OtherEvidence.class));
                 verify(applicationEventPublisher).publishEvent(argThat((Object event) ->
                         event instanceof ScoreUpdatedEvent &&
                                 ((ScoreUpdatedEvent) event).studentCode().equals(studentDetail.getStudentCode())

--- a/src/test/java/team/incude/gsmc/v2/domain/evidence/application/usecase/service/CreateReadingEvidenceServiceTest.java
+++ b/src/test/java/team/incude/gsmc/v2/domain/evidence/application/usecase/service/CreateReadingEvidenceServiceTest.java
@@ -91,7 +91,7 @@ public class CreateReadingEvidenceServiceTest {
 
                 // then
                 verify(scorePersistencePort).saveScore(any(Score.class));
-                verify(readingEvidencePersistencePort).saveReadingEvidence(any(ReadingEvidence.class));
+                verify(readingEvidencePersistencePort).saveReadingEvidence(any(), any(ReadingEvidence.class));
                 verify(applicationEventPublisher).publishEvent(argThat((Object event) ->
                         event instanceof ScoreUpdatedEvent &&
                                 ((ScoreUpdatedEvent) event).studentCode().equals(studentDetail.getStudentCode())

--- a/src/test/java/team/incude/gsmc/v2/domain/score/application/usecase/service/UpdateScoreServiceTest.java
+++ b/src/test/java/team/incude/gsmc/v2/domain/score/application/usecase/service/UpdateScoreServiceTest.java
@@ -19,6 +19,8 @@ import team.incude.gsmc.v2.domain.score.domain.Score;
 import team.incude.gsmc.v2.global.event.ScoreUpdatedEvent;
 import team.incude.gsmc.v2.global.security.jwt.application.usecase.service.CurrentMemberProvider;
 
+import java.util.List;
+
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.verify;
@@ -30,22 +32,16 @@ class UpdateScoreServiceTest {
 
     @Mock
     private ScorePersistencePort scorePersistencePort;
-
     @Mock
     private CategoryPersistencePort categoryPersistencePort;
-
     @Mock
     private MemberPersistencePort memberPersistencePort;
-
     @Mock
     private StudentDetailPersistencePort studentDetailPersistencePort;
-
     @Mock
     private CurrentMemberProvider currentMemberProvider;
-
     @Mock
     private ApplicationEventPublisher applicationEventPublisher;
-
     @InjectMocks
     private UpdateScoreService updateScoreService;
 
@@ -77,7 +73,7 @@ class UpdateScoreServiceTest {
                         .build();
                 when(currentMemberProvider.getCurrentUser()).thenReturn(member);
                 when(studentDetailPersistencePort.findStudentDetailByMemberEmail(email)).thenReturn(studentDetail);
-                when(categoryPersistencePort.findCategoryByName(categoryName)).thenReturn(category);
+                when(categoryPersistencePort.findAllCategory()).thenReturn(List.of(category));
                 when(scorePersistencePort.findScoreByCategoryNameAndStudentDetailStudentCodeWithLock(categoryName, studentCode)).thenReturn(null);
                 when(memberPersistencePort.findMemberByStudentDetailStudentCode(studentCode)).thenReturn(member);
 
@@ -124,7 +120,7 @@ class UpdateScoreServiceTest {
                         .build();
                 when(currentMemberProvider.getCurrentUser()).thenReturn(member);
                 when(studentDetailPersistencePort.findStudentDetailByMemberEmail(email)).thenReturn(studentDetail);
-                when(categoryPersistencePort.findCategoryByName(categoryName)).thenReturn(category);
+                when(categoryPersistencePort.findAllCategory()).thenReturn(List.of(category));
                 when(scorePersistencePort.findScoreByCategoryNameAndStudentDetailStudentCodeWithLock(categoryName, studentCode)).thenReturn(existingScore);
 
                 // when
@@ -165,7 +161,7 @@ class UpdateScoreServiceTest {
                         .maximumValue(5)
                         .isEvidenceRequired(false)
                         .build();
-                when(categoryPersistencePort.findCategoryByName(categoryName)).thenReturn(category);
+                when(categoryPersistencePort.findAllCategory()).thenReturn(List.of(category));
                 when(scorePersistencePort.findScoreByCategoryNameAndStudentDetailStudentCodeWithLock(categoryName, studentCode)).thenReturn(null);
                 when(memberPersistencePort.findMemberByStudentDetailStudentCode(studentCode)).thenReturn(member);
 
@@ -208,7 +204,7 @@ class UpdateScoreServiceTest {
                         .category(category)
                         .value(1)
                         .build();
-                when(categoryPersistencePort.findCategoryByName(categoryName)).thenReturn(category);
+                when(categoryPersistencePort.findAllCategory()).thenReturn(List.of(category));
                 when(scorePersistencePort.findScoreByCategoryNameAndStudentDetailStudentCodeWithLock(categoryName, studentCode)).thenReturn(existingScore);
 
                 // when

--- a/src/test/java/team/incude/gsmc/v2/domain/score/application/usecase/service/UpdateScoreServiceTest.java
+++ b/src/test/java/team/incude/gsmc/v2/domain/score/application/usecase/service/UpdateScoreServiceTest.java
@@ -16,11 +16,13 @@ import team.incude.gsmc.v2.domain.score.application.port.CategoryPersistencePort
 import team.incude.gsmc.v2.domain.score.application.port.ScorePersistencePort;
 import team.incude.gsmc.v2.domain.score.domain.Category;
 import team.incude.gsmc.v2.domain.score.domain.Score;
+import team.incude.gsmc.v2.domain.score.exception.CategoryNotFoundException;
 import team.incude.gsmc.v2.global.event.ScoreUpdatedEvent;
 import team.incude.gsmc.v2.global.security.jwt.application.usecase.service.CurrentMemberProvider;
 
 import java.util.List;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.verify;
@@ -220,6 +222,26 @@ class UpdateScoreServiceTest {
                         event instanceof ScoreUpdatedEvent &&
                                 ((ScoreUpdatedEvent) event).studentCode().equals(studentCode)
                 ));
+            }
+        }
+
+        @Nested
+        @DisplayName("존재하지 않는 카테고리 이름이 주어지면")
+        class Context_when_category_not_exists {
+
+            @Test
+            @DisplayName("예외를 발생시킨다")
+            void it_throws_exception() {
+                // given
+                String studentCode = "24058";
+                String categoryName = "NON_EXISTENT_CATEGORY";
+                int value = 3;
+                when(categoryPersistencePort.findAllCategory()).thenReturn(List.of());
+
+                // when & then
+                assertThrows(CategoryNotFoundException.class, () -> {
+                    updateScoreService.execute(studentCode, categoryName, value);
+                });
             }
         }
     }

--- a/src/test/java/team/incude/gsmc/v2/domain/score/application/usecase/service/UpdateScoreServiceTest.java
+++ b/src/test/java/team/incude/gsmc/v2/domain/score/application/usecase/service/UpdateScoreServiceTest.java
@@ -23,6 +23,7 @@ import team.incude.gsmc.v2.global.security.jwt.application.usecase.service.Curre
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.verify;
@@ -34,16 +35,22 @@ class UpdateScoreServiceTest {
 
     @Mock
     private ScorePersistencePort scorePersistencePort;
+
     @Mock
     private CategoryPersistencePort categoryPersistencePort;
+
     @Mock
     private MemberPersistencePort memberPersistencePort;
+
     @Mock
     private StudentDetailPersistencePort studentDetailPersistencePort;
+
     @Mock
     private CurrentMemberProvider currentMemberProvider;
+
     @Mock
     private ApplicationEventPublisher applicationEventPublisher;
+
     @InjectMocks
     private UpdateScoreService updateScoreService;
 


### PR DESCRIPTION
## 📋 작업 내용
> 캐싱을 단건 조회 메서드에 적용한 것이 아니라 전체 조회 메서드에 적용후 필터링 하는 방식으로 변경하였습니다

## 🤝 리뷰 시 참고사항
> 혹시나 누락된 ``findCategoryByName`` 메서드 사용 구간이 있는지 확인바랍니다,누락된 테스트 케이스가 있는지도 확인바랍니다.

## ✅ 체크리스트
- [x] 이 작업으로 인해 변경이 필요한 문서를 작성 또는 수정했나요? (e.g. `README`, `.env.example`)
- [x] 작업한 코드가 정상적으로 동작하는지 확인했나요?
- [x] 작업한 코드에 대한 테스트 코드를 작성하거나 수정했나요?
- [x] Merge 대상 브랜치를 올바르게 설정했나요?
- [x] 해당 PR과 관련 없는 작업이 포함되지는 않았나요?
- [x] PR의 올바른 라벨과 리뷰어를 설정했나요?