### PR TITLE
사용자 조회 시 동일 사용자 동시 조회 문제 수정

### DIFF
--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -1,4 +1,7 @@
 spring:
+  docker:
+    compose:
+      enabled: false
   config:
     activate:
       on-profile: prod


### PR DESCRIPTION
## 📋 작업 내용
> 사용자 리스트를 요청 시 동일한 사용자 객체가 여러 건 포함되어 전송되던 문제를 해결하였습니다,부가적으로 ``prod`` 프로파일에서 **Docker Compose Support``가 오작동 할 위험성을 막기 위해 명시적으로 ``false`` 처리하였습니다

## 🤝 리뷰 시 참고사항
> 기존 서브쿼리 방식으로 해결이 덜 되어서 ``distinct()`` 함수 방식과 집계 함수들을 위하여 ``min()`` 함수를 이용하는 방식 중 성능이 비교적 더 좋은 ``min()``을 사용했는데 실제로 더 좋을 지 모르겠습니다

## ✅ 체크리스트
- [x] 이 작업으로 인해 변경이 필요한 문서를 작성 또는 수정했나요? (e.g. `README`, `.env.example`)
- [x] 작업한 코드가 정상적으로 동작하는지 확인했나요?
- [x] 작업한 코드에 대한 테스트 코드를 작성하거나 수정했나요?
- [x] Merge 대상 브랜치를 올바르게 설정했나요?
- [x] 해당 PR과 관련 없는 작업이 포함되지는 않았나요?
- [x] PR의 올바른 라벨과 리뷰어를 설정했나요?