### PR TITLE
증빙자료 이미지 업로드 실패 시 재시도 큐 추가 및 수정 서비스 클래스 수정

### DIFF
--- a/src/main/java/team/incude/gsmc/v2/domain/evidence/application/EvidenceApplicationAdapter.java
+++ b/src/main/java/team/incude/gsmc/v2/domain/evidence/application/EvidenceApplicationAdapter.java
@@ -72,16 +72,16 @@ public class EvidenceApplicationAdapter implements EvidenceApplicationPort {
      * 전공 활동 증빙자료를 수정합니다.
      */
     @Override
-    public void updateMajorEvidenceByCurrentUser(Long evidenceId, String title, String content, MultipartFile file, String imageUrl) {
-        updateActivityEvidenceByCurrentUserUseCase.execute(evidenceId, title, content, file, EvidenceType.MAJOR, imageUrl);
+    public void updateMajorEvidenceByCurrentUser(Long evidenceId, String title, String content, MultipartFile file) {
+        updateActivityEvidenceByCurrentUserUseCase.execute(evidenceId, title, content, file, EvidenceType.MAJOR);
     }
 
     /**
      * 인문 활동 증빙자료를 수정합니다.
      */
     @Override
-    public void updateHumanitiesEvidenceByCurrentUser(Long evidenceId, String title, String content, MultipartFile file, String imageUrl) {
-        updateActivityEvidenceByCurrentUserUseCase.execute(evidenceId, title, content, file, EvidenceType.HUMANITIES, imageUrl);
+    public void updateHumanitiesEvidenceByCurrentUser(Long evidenceId, String title, String content, MultipartFile file) {
+        updateActivityEvidenceByCurrentUserUseCase.execute(evidenceId, title, content, file, EvidenceType.HUMANITIES);
     }
 
     /**
@@ -96,8 +96,8 @@ public class EvidenceApplicationAdapter implements EvidenceApplicationPort {
      * 기타 증빙자료를 수정합니다.
      */
     @Override
-    public void updateOtherEvidenceByCurrentUser(Long evidenceId, MultipartFile file, String imageUrl) {
-        updateOtherEvidenceByCurrentUserUseCase.execute(evidenceId, file, imageUrl);
+    public void updateOtherEvidenceByCurrentUser(Long evidenceId, MultipartFile file) {
+        updateOtherEvidenceByCurrentUserUseCase.execute(evidenceId, file);
     }
 
     /**
@@ -152,8 +152,8 @@ public class EvidenceApplicationAdapter implements EvidenceApplicationPort {
      * 점수 기반 기타 증빙자료를 수정합니다.
      */
     @Override
-    public void updateOtherScoringEvidenceByCurrentUser(Long evidenceId, MultipartFile file, int value, String imageUrl) {
-        updateOtherScoringUseCase.execute(evidenceId, file, value, imageUrl);
+    public void updateOtherScoringEvidenceByCurrentUser(Long evidenceId, MultipartFile file, int value) {
+        updateOtherScoringUseCase.execute(evidenceId, file, value);
     }
 
     /**
@@ -196,8 +196,11 @@ public class EvidenceApplicationAdapter implements EvidenceApplicationPort {
         return findDraftEvidenceByCurrentUserUseCase.execute();
     }
 
+    /**
+     * 증빙자료의 이미지 파일을 수정합니다.
+     */
     @Override
-    public void updateEvidenceFile(Long evidenceId, String fileName, InputStream inputStream, EvidenceType evidenceType) {
-        updateEvidenceFileUseCase.execute(evidenceId, fileName, inputStream, evidenceType);
+    public void updateEvidenceFile(Long evidenceId, String fileName, InputStream inputStream, EvidenceType evidenceType, String email) {
+        updateEvidenceFileUseCase.execute(evidenceId, fileName, inputStream, evidenceType, email);
     }
 }

--- a/src/main/java/team/incude/gsmc/v2/domain/evidence/application/consumer/RetryFileUploadConsumer.java
+++ b/src/main/java/team/incude/gsmc/v2/domain/evidence/application/consumer/RetryFileUploadConsumer.java
@@ -1,0 +1,67 @@
+package team.incude.gsmc.v2.domain.evidence.application.consumer;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import team.incude.gsmc.v2.domain.evidence.application.port.EvidenceApplicationPort;
+import team.incude.gsmc.v2.domain.evidence.application.port.RetryUploadZSetPort;
+import team.incude.gsmc.v2.domain.evidence.presentation.data.FileUploadRetryMessageDto;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.util.Set;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class RetryFileUploadConsumer {
+
+    private final RetryUploadZSetPort retryUploadZSetPort;
+    private final EvidenceApplicationPort evidenceApplicationPort;
+
+    @Scheduled(fixedDelay = 10_000)
+    public void consume() {
+        try {
+            long now = System.currentTimeMillis();
+            Set<FileUploadRetryMessageDto> messageDtos = retryUploadZSetPort.pollReadyToRetry(now);
+
+            for (FileUploadRetryMessageDto message : messageDtos) {
+                try {
+                    File file = new File(message.tempFilePath());
+
+                    if (!file.exists()) {
+                        log.warn("임시 파일이 존재하지 않습니다. 재시도 생략: {}", message.tempFilePath());
+                        retryUploadZSetPort.removeMessage(message);
+                        continue;
+                    }
+
+                    try (InputStream inputStream = Files.newInputStream(file.toPath())) {
+                        evidenceApplicationPort.updateEvidenceFile(
+                                message.evidenceId(),
+                                message.fileName(),
+                                inputStream,
+                                message.evidenceType(),
+                                message.email()
+                        );
+
+                        retryUploadZSetPort.removeMessage(message);
+
+                        if (!file.delete()) {
+                            log.warn("임시 파일 삭제 실패: {}", file.getAbsolutePath());
+                        }
+                    }
+                } catch (IOException e) {
+                    log.error("업로드 재시도 실패", e);
+                    retryUploadZSetPort.scheduleRetry(message, System.currentTimeMillis() + 60_000); // 1분 뒤 재등록
+                } catch (Exception e) {
+                    log.error("단일 재시도 메시지 처리 중 예외 발생", e);
+                }
+            }
+        } catch (Exception e) {
+            log.error("스케줄링 전체 처리 중 예외 발생", e);
+        }
+    }
+}

--- a/src/main/java/team/incude/gsmc/v2/domain/evidence/application/consumer/RetryFileUploadConsumer.java
+++ b/src/main/java/team/incude/gsmc/v2/domain/evidence/application/consumer/RetryFileUploadConsumer.java
@@ -22,6 +22,8 @@ public class RetryFileUploadConsumer {
     private final RetryUploadZSetPort retryUploadZSetPort;
     private final EvidenceApplicationPort evidenceApplicationPort;
 
+    private static final long RETRY_DELAY_MILLIS = 60_000L;
+
     @Scheduled(fixedDelay = 10_000)
     public void consume() {
         try {
@@ -55,7 +57,7 @@ public class RetryFileUploadConsumer {
                     }
                 } catch (IOException e) {
                     log.error("업로드 재시도 실패", e);
-                    retryUploadZSetPort.scheduleRetry(message, System.currentTimeMillis() + 60_000); // 1분 뒤 재등록
+                    retryUploadZSetPort.scheduleRetry(message, System.currentTimeMillis() + RETRY_DELAY_MILLIS);
                 } catch (Exception e) {
                     log.error("단일 재시도 메시지 처리 중 예외 발생", e);
                 }

--- a/src/main/java/team/incude/gsmc/v2/domain/evidence/application/consumer/RetryFileUploadConsumer.java
+++ b/src/main/java/team/incude/gsmc/v2/domain/evidence/application/consumer/RetryFileUploadConsumer.java
@@ -14,6 +14,14 @@ import java.io.InputStream;
 import java.nio.file.Files;
 import java.util.Set;
 
+/**
+ * Redis ZSet 기반 재시도 큐에 등록된 파일 업로드 요청을 소비하여 처리하는 컨슈머 클래스입니다.
+ * <p>파일 업로드 실패 시 임시 파일 경로와 메타 정보를 {@link FileUploadRetryMessageDto} 형태로 ZSet에 저장하고,
+ * 해당 시간이 도래하면 이를 읽어 업로드를 재시도합니다.</p>
+ * <p>업로드 성공 시 메시지를 제거하고 임시 파일을 삭제하며,
+ * 실패 시 지정된 지연 시간 이후 다시 재시도하도록 스케줄링합니다.</p>
+ * @author suuuuuuminnnnnn
+ */
 @Component
 @RequiredArgsConstructor
 @Slf4j
@@ -24,6 +32,14 @@ public class RetryFileUploadConsumer {
 
     private static final long RETRY_DELAY_MILLIS = 60_000L;
 
+    /**
+     * 재시도 대상 파일 업로드 메시지를 주기적으로 확인하고, 업로드를 재시도합니다.
+     * <p>1. 현재 시간 이전으로 예약된 메시지를 조회합니다.
+     * <br>2. 임시 파일이 존재하지 않으면 메시지를 제거하고 스킵합니다.
+     * <br>3. 파일이 존재하면 다시 업로드 시도 후, 성공 시 삭제/제거, 실패 시 재스케줄합니다.</p>
+     * <p>{@code @Scheduled} 애노테이션으로 10초마다 실행되며,
+     * 시스템 오류가 발생하더라도 전체 처리가 중단되지 않도록 내부 예외 처리를 포함합니다.</p>
+     */
     @Scheduled(fixedDelay = 10_000)
     public void consume() {
         try {

--- a/src/main/java/team/incude/gsmc/v2/domain/evidence/application/port/EvidenceApplicationPort.java
+++ b/src/main/java/team/incude/gsmc/v2/domain/evidence/application/port/EvidenceApplicationPort.java
@@ -27,13 +27,13 @@ public interface EvidenceApplicationPort {
 
     GetEvidencesResponse findEvidenceByTitleAndType(String title, EvidenceType evidenceType);
 
-    void updateMajorEvidenceByCurrentUser(Long evidenceId, String title, String content, MultipartFile file, String imageUrl);
+    void updateMajorEvidenceByCurrentUser(Long evidenceId, String title, String content, MultipartFile file);
 
-    void updateHumanitiesEvidenceByCurrentUser(Long evidenceId, String title, String content, MultipartFile file, String imageUrl);
+    void updateHumanitiesEvidenceByCurrentUser(Long evidenceId, String title, String content, MultipartFile file);
 
     void updateReadingEvidenceByCurrentUser(Long evidenceId, String title, String author, String content, int page);
 
-    void updateOtherEvidenceByCurrentUser(Long evidenceId, MultipartFile file, String imageUrl);
+    void updateOtherEvidenceByCurrentUser(Long evidenceId, MultipartFile fi);
 
     void deleteEvidence(Long evidenceId);
 
@@ -47,7 +47,7 @@ public interface EvidenceApplicationPort {
 
     void createOtherScoringEvidence(String categoryName, MultipartFile file, int value);
 
-    void updateOtherScoringEvidenceByCurrentUser(Long evidenceId, MultipartFile file, int value, String imageUrl);
+    void updateOtherScoringEvidenceByCurrentUser(Long evidenceId, MultipartFile file, int value);
 
     CreateDraftEvidenceResponse createDraftActivityEvidence(UUID draftId, String categoryName, String title, String content, MultipartFile file, String imageUrl, EvidenceType activityType);
 
@@ -59,5 +59,5 @@ public interface EvidenceApplicationPort {
 
     GetDraftEvidenceResponse findDraftEvidenceByCurrentUser();
 
-    void updateEvidenceFile(Long evidenceId, String fileName, InputStream inputStream, EvidenceType evidenceType);
+    void updateEvidenceFile(Long evidenceId, String fileName, InputStream inputStream, EvidenceType evidenceType, String email);
 }

--- a/src/main/java/team/incude/gsmc/v2/domain/evidence/application/port/RedisPort.java
+++ b/src/main/java/team/incude/gsmc/v2/domain/evidence/application/port/RedisPort.java
@@ -1,0 +1,12 @@
+package team.incude.gsmc.v2.domain.evidence.application.port;
+
+import team.incude.gsmc.v2.domain.evidence.domain.RetryUploadCommand;
+import team.incude.gsmc.v2.global.annotation.PortDirection;
+import team.incude.gsmc.v2.global.annotation.port.Port;
+
+import java.io.InputStream;
+
+@Port(direction = PortDirection.INBOUND)
+public interface RedisPort {
+    void scheduleRetry(RetryUploadCommand command, InputStream inputStream, long retryTimeMillis);
+}

--- a/src/main/java/team/incude/gsmc/v2/domain/evidence/application/port/RedisPort.java
+++ b/src/main/java/team/incude/gsmc/v2/domain/evidence/application/port/RedisPort.java
@@ -6,6 +6,12 @@ import team.incude.gsmc.v2.global.annotation.port.Port;
 
 import java.io.InputStream;
 
+/**
+ * 파일 업로드 실패 시 재시도 처리를 위한 Redis 기반 포트입니다.
+ * <p>업로드 실패 파일을 일정 시간 이후 재시도할 수 있도록 Redis ZSet 또는 유사한 자료구조에 등록합니다.
+ * <br>재시도 시 필요한 파일 스트림, 메타 정보, 실행 시간을 함께 저장하여, 소비자가 재시도 처리를 수행할 수 있게 합니다.</p>
+ * 이 인터페이스는 {@code @Port} 어노테이션을 통해 INBOUND 방향으로 지정되어 있습니다.
+ */
 @Port(direction = PortDirection.INBOUND)
 public interface RedisPort {
     void scheduleRetry(RetryUploadCommand command, InputStream inputStream, long retryTimeMillis);

--- a/src/main/java/team/incude/gsmc/v2/domain/evidence/application/port/RetryUploadZSetPort.java
+++ b/src/main/java/team/incude/gsmc/v2/domain/evidence/application/port/RetryUploadZSetPort.java
@@ -6,7 +6,13 @@ import team.incude.gsmc.v2.global.annotation.port.Port;
 
 import java.util.Set;
 
-@Port(direction = PortDirection.INBOUND)
+/**
+ * 파일 업로드 실패 시 재시도 처리를 위한 Redis ZSet 기반 포트입니다.
+ * <p>업로드 실패 파일을 Redis의 ZSet 등에 일정 시간 이후 재시도 대상으로 등록하고,
+ * 조건이 충족되면 메시지를 폴링하여 실제 업로드 작업이 재시도될 수 있도록 지원합니다.</p>
+ * 이 인터페이스는 {@code @Port} 어노테이션을 통해 OUTBOUND 방향으로 지정되어 있습니다.
+ */
+@Port(direction = PortDirection.OUTBOUND)
 public interface RetryUploadZSetPort {
     void scheduleRetry(FileUploadRetryMessageDto message, long retryTimeMillis);
 

--- a/src/main/java/team/incude/gsmc/v2/domain/evidence/application/port/RetryUploadZSetPort.java
+++ b/src/main/java/team/incude/gsmc/v2/domain/evidence/application/port/RetryUploadZSetPort.java
@@ -1,0 +1,16 @@
+package team.incude.gsmc.v2.domain.evidence.application.port;
+
+import team.incude.gsmc.v2.domain.evidence.presentation.data.FileUploadRetryMessageDto;
+import team.incude.gsmc.v2.global.annotation.PortDirection;
+import team.incude.gsmc.v2.global.annotation.port.Port;
+
+import java.util.Set;
+
+@Port(direction = PortDirection.INBOUND)
+public interface RetryUploadZSetPort {
+    void scheduleRetry(FileUploadRetryMessageDto message, long retryTimeMillis);
+
+    Set<FileUploadRetryMessageDto> pollReadyToRetry(long nowMillis);
+
+    void removeMessage(FileUploadRetryMessageDto message);
+}

--- a/src/main/java/team/incude/gsmc/v2/domain/evidence/application/usecase/RetryFileUploadUseCase.java
+++ b/src/main/java/team/incude/gsmc/v2/domain/evidence/application/usecase/RetryFileUploadUseCase.java
@@ -1,0 +1,14 @@
+package team.incude.gsmc.v2.domain.evidence.application.usecase;
+
+import team.incude.gsmc.v2.domain.evidence.domain.RetryUploadCommand;
+
+import java.io.InputStream;
+
+/**
+ * 파일 업로드 재시도 유스케이스 인터페이스입니다.
+ * <p>재시도 커맨드와 파일 스트림, 지연 시간을 받아 재시도 큐에 등록하거나 즉시 재시도를 수행합니다.
+ * @author suuuuuuminnnnnn
+ */
+public interface RetryFileUploadUseCase {
+    void execute(RetryUploadCommand retryUploadCommand, InputStream inputStream, long delayMillis);
+}

--- a/src/main/java/team/incude/gsmc/v2/domain/evidence/application/usecase/UpdateActivityEvidenceByCurrentUserUseCase.java
+++ b/src/main/java/team/incude/gsmc/v2/domain/evidence/application/usecase/UpdateActivityEvidenceByCurrentUserUseCase.java
@@ -11,5 +11,5 @@ import team.incude.gsmc.v2.domain.evidence.domain.constant.EvidenceType;
  * @author suuuuuuminnnnnn
  */
 public interface UpdateActivityEvidenceByCurrentUserUseCase {
-    void execute(Long evidenceId, String title, String content, MultipartFile file, EvidenceType evidenceType, String imageUrl);
+    void execute(Long evidenceId, String title, String content, MultipartFile file, EvidenceType evidenceType);
 }

--- a/src/main/java/team/incude/gsmc/v2/domain/evidence/application/usecase/UpdateEvidenceFileUseCase.java
+++ b/src/main/java/team/incude/gsmc/v2/domain/evidence/application/usecase/UpdateEvidenceFileUseCase.java
@@ -5,5 +5,5 @@ import team.incude.gsmc.v2.domain.evidence.domain.constant.EvidenceType;
 import java.io.InputStream;
 
 public interface UpdateEvidenceFileUseCase {
-    void execute(Long evidenceId, String fileName, InputStream inputStream, EvidenceType evidenceType);
+    void execute(Long evidenceId, String fileName, InputStream inputStream, EvidenceType evidenceType, String email);
 }

--- a/src/main/java/team/incude/gsmc/v2/domain/evidence/application/usecase/UpdateOtherEvidenceByCurrentUserUseCase.java
+++ b/src/main/java/team/incude/gsmc/v2/domain/evidence/application/usecase/UpdateOtherEvidenceByCurrentUserUseCase.java
@@ -9,5 +9,5 @@ import org.springframework.web.multipart.MultipartFile;
  * @author suuuuuuminnnnnn
  */
 public interface UpdateOtherEvidenceByCurrentUserUseCase {
-    void execute(Long evidenceId, MultipartFile file, String imageUrl);
+    void execute(Long evidenceId, MultipartFile file);
 }

--- a/src/main/java/team/incude/gsmc/v2/domain/evidence/application/usecase/UpdateOtherScoringEvidenceByCurrentUserUseCase.java
+++ b/src/main/java/team/incude/gsmc/v2/domain/evidence/application/usecase/UpdateOtherScoringEvidenceByCurrentUserUseCase.java
@@ -11,5 +11,5 @@ import org.springframework.web.multipart.MultipartFile;
  * @author suuuuuuminnnnnn
  */
 public interface UpdateOtherScoringEvidenceByCurrentUserUseCase {
-    void execute(Long evidenceId, MultipartFile file, int value, String imageUrl);
+    void execute(Long evidenceId, MultipartFile file, int value);
 }

--- a/src/main/java/team/incude/gsmc/v2/domain/evidence/application/usecase/service/CreateActivityEvidenceService.java
+++ b/src/main/java/team/incude/gsmc/v2/domain/evidence/application/usecase/service/CreateActivityEvidenceService.java
@@ -94,7 +94,9 @@ public class CreateActivityEvidenceService implements CreateActivityEvidenceUseC
                         evidence.getId(),
                         file.getOriginalFilename(),
                         file.getInputStream(),
-                        evidence.getEvidenceType()));
+                        evidence.getEvidenceType(),
+                        member.getEmail()
+                ));
             } catch (IOException e) {
                 discordPort.sendEvidenceUploadFailureAlert(
                         evidence.getId(),
@@ -137,7 +139,7 @@ public class CreateActivityEvidenceService implements CreateActivityEvidenceUseC
         String imageUrl = null;
 
         if (file != null && !file.isEmpty()) {
-            imageUrl = "upload_" + file.getOriginalFilename();
+            imageUrl = "upload_" + file.getOriginalFilename() + UUID.randomUUID();
         } else if (imageUrlParam != null && !imageUrlParam.isBlank()) {
             imageUrl = imageUrlParam;
         }

--- a/src/main/java/team/incude/gsmc/v2/domain/evidence/application/usecase/service/CreateOtherEvidenceService.java
+++ b/src/main/java/team/incude/gsmc/v2/domain/evidence/application/usecase/service/CreateOtherEvidenceService.java
@@ -29,6 +29,7 @@ import team.incude.gsmc.v2.global.util.ValueLimiterUtil;
 import java.io.IOException;
 import java.time.LocalDateTime;
 import java.util.Map;
+import java.util.UUID;
 
 /**
  * 기타 증빙자료 생성을 담당하는 유스케이스 구현 클래스입니다.
@@ -85,7 +86,8 @@ public class CreateOtherEvidenceService implements CreateOtherEvidenceUseCase {
                     evidence.getId(),
                     file.getOriginalFilename(),
                     file.getInputStream(),
-                    evidence.getEvidenceType()
+                    evidence.getEvidenceType(),
+                    member.getEmail()
             ));
         } catch (IOException e) {
             discordPort.sendEvidenceUploadFailureAlert(
@@ -122,7 +124,7 @@ public class CreateOtherEvidenceService implements CreateOtherEvidenceUseCase {
      * @return 생성된 OtherEvidence 객체
      */
     private OtherEvidence createOtherEvidence(Evidence evidence, String fileName) {
-        String tempUploadKey = "upload_" + fileName;
+        String tempUploadKey = "upload_" + fileName + UUID.randomUUID();
 
         return OtherEvidence.builder()
                 .id(evidence)

--- a/src/main/java/team/incude/gsmc/v2/domain/evidence/application/usecase/service/CreateOtherScoringEvidenceService.java
+++ b/src/main/java/team/incude/gsmc/v2/domain/evidence/application/usecase/service/CreateOtherScoringEvidenceService.java
@@ -29,6 +29,7 @@ import team.incude.gsmc.v2.global.util.ValueLimiterUtil;
 import java.io.IOException;
 import java.time.LocalDateTime;
 import java.util.Map;
+import java.util.UUID;
 
 
 /**
@@ -95,7 +96,8 @@ public class CreateOtherScoringEvidenceService implements CreateOtherScoringEvid
                     evidence.getId(),
                     file.getOriginalFilename(),
                     file.getInputStream(),
-                    evidence.getEvidenceType()
+                    evidence.getEvidenceType(),
+                    member.getEmail()
             ));
         } catch (IOException e) {
             discordPort.sendEvidenceUploadFailureAlert(
@@ -173,7 +175,7 @@ public class CreateOtherScoringEvidenceService implements CreateOtherScoringEvid
      * @return 생성된 OtherEvidence 객체
      */
     private OtherEvidence createOtherEvidence(Evidence evidence, MultipartFile file) {
-        String tempUploadKey = "upload_" + file.getOriginalFilename();
+        String tempUploadKey = "upload_" + file.getOriginalFilename() + UUID.randomUUID();
 
         return OtherEvidence.builder()
                 .id(evidence)

--- a/src/main/java/team/incude/gsmc/v2/domain/evidence/application/usecase/service/RetryFileUploadService.java
+++ b/src/main/java/team/incude/gsmc/v2/domain/evidence/application/usecase/service/RetryFileUploadService.java
@@ -1,0 +1,80 @@
+package team.incude.gsmc.v2.domain.evidence.application.usecase.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import team.incude.gsmc.v2.domain.evidence.application.port.RetryUploadZSetPort;
+import team.incude.gsmc.v2.domain.evidence.application.usecase.RetryFileUploadUseCase;
+import team.incude.gsmc.v2.domain.evidence.domain.RetryUploadCommand;
+import team.incude.gsmc.v2.domain.evidence.presentation.data.FileUploadRetryMessageDto;
+import team.incude.gsmc.v2.global.redis.mapper.RetryUploadMapper;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+
+/**
+ * S3 업로드 실패 시 파일을 임시 저장하고 재시도 큐에 등록하는 유스케이스 구현 클래스입니다.
+ * <p>임시 파일로 저장한 후, 해당 경로를 포함하는 메시지를 Redis ZSet에 등록하여
+ * 일정 시간 이후 재업로드가 시도되도록 구성됩니다.
+ * <p>파일 복사 중 예외 발생 시 임시 파일을 삭제하고, 재시도 등록 실패 로그를 출력합니다.
+ * @author suuuuuuminnnnnn
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional
+@Slf4j
+public class RetryFileUploadService implements RetryFileUploadUseCase {
+
+    private final RetryUploadMapper retryUploadMapper;
+    private final RetryUploadZSetPort retryUploadZSetPort;
+
+    /**
+     * S3 업로드 실패 시 파일을 임시 경로에 복사하고, 재시도 큐(Redis ZSet)에 등록합니다.
+     * <ul>
+     *     <li>임시 디렉터리에 파일을 저장합니다 (시스템 기본 temp 디렉토리).</li>
+     *     <li>경로 포함 정보를 메시지로 만들어 Redis에 등록합니다.</li>
+     *     <li>예외 발생 시 임시 파일은 삭제됩니다.</li>
+     * </ul>
+     * @param command 업로드 실패 관련 정보(evidenceId, 파일 이름 등)
+     * @param inputStream 업로드 실패한 파일의 스트림
+     * @param delayMillis 재시도까지 대기할 시간 (ms)
+     * @throws RuntimeException 파일 복사나 등록 중 예외가 발생한 경우
+     */
+    @Override
+    public void execute(RetryUploadCommand command, InputStream inputStream, long delayMillis) {
+        Path tempFile = null;
+
+        try {
+            tempFile = Files.createTempFile("evidence-", "-" + command.getFileName());
+
+            Files.copy(inputStream, tempFile, StandardCopyOption.REPLACE_EXISTING);
+
+            RetryUploadCommand commandWithPath = RetryUploadCommand.builder()
+                    .commandId(command.getCommandId())
+                    .evidenceId(command.getEvidenceId())
+                    .fileName(command.getFileName())
+                    .tempFilePath(tempFile.toAbsolutePath().toString())
+                    .evidenceType(command.getEvidenceType())
+                    .email(command.getEmail())
+                    .build();
+
+            FileUploadRetryMessageDto message = retryUploadMapper.toMessage(commandWithPath);
+            retryUploadZSetPort.scheduleRetry(message, System.currentTimeMillis() + delayMillis);
+
+        } catch (IOException e) {
+            if (tempFile != null && Files.exists(tempFile)) {
+                try {
+                    Files.delete(tempFile);
+                } catch (IOException deleteEx) {
+                    log.warn("임시 파일 삭제 실패: {}", tempFile.toAbsolutePath(), deleteEx);
+                }
+            }
+            log.error("파일 복사 및 재시도 큐 등록 중 예외 발생", e);
+            throw new RuntimeException("파일 재시도 큐 등록 실패", e);
+        }
+    }
+}

--- a/src/main/java/team/incude/gsmc/v2/domain/evidence/application/usecase/service/UpdateActivityEvidenceByCurrentUserService.java
+++ b/src/main/java/team/incude/gsmc/v2/domain/evidence/application/usecase/service/UpdateActivityEvidenceByCurrentUserService.java
@@ -1,10 +1,12 @@
 package team.incude.gsmc.v2.domain.evidence.application.usecase.service;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 import team.incude.gsmc.v2.domain.evidence.application.port.ActivityEvidencePersistencePort;
+import team.incude.gsmc.v2.domain.evidence.application.port.DiscordPort;
 import team.incude.gsmc.v2.domain.evidence.application.port.EvidencePersistencePort;
 import team.incude.gsmc.v2.domain.evidence.application.port.S3Port;
 import team.incude.gsmc.v2.domain.evidence.application.usecase.UpdateActivityEvidenceByCurrentUserUseCase;
@@ -12,16 +14,20 @@ import team.incude.gsmc.v2.domain.evidence.domain.ActivityEvidence;
 import team.incude.gsmc.v2.domain.evidence.domain.Evidence;
 import team.incude.gsmc.v2.domain.evidence.domain.constant.EvidenceType;
 import team.incude.gsmc.v2.domain.evidence.domain.constant.ReviewStatus;
+import team.incude.gsmc.v2.global.event.FileUploadEvent;
+import team.incude.gsmc.v2.global.event.ScoreUpdatedEvent;
+import team.incude.gsmc.v2.global.security.jwt.application.usecase.service.CurrentMemberProvider;
 import team.incude.gsmc.v2.global.thirdparty.aws.exception.S3UploadFailedException;
 
 import java.io.IOException;
 import java.time.LocalDateTime;
+import java.util.UUID;
 
 /**
  * 활동 증빙자료 수정을 처리하는 유스케이스 구현 클래스입니다.
  * <p>{@link UpdateActivityEvidenceByCurrentUserUseCase}를 구현하며,
  * 제목, 내용, 이미지 URL, 증빙자료 유형 등을 기반으로 기존 활동 증빙자료를 수정합니다.
- * <p>파일이 새로 첨부되거나 이미지 URL이 변경된 경우, 기존 이미지를 S3에서 삭제하고 새 파일을 업로드합니다.
+ * <p>파일이 새로 첨부되거나 이미지 URL이 변경된 경우, 기존 이미지는 즉시 삭제되며, 새 파일은 이벤트 기반 업로드됩니다.
  * <p>수정 시 검토 상태는 항상 {@code PENDING}으로 초기화됩니다.
  * @author suuuuuuminnnnnn
  */
@@ -31,80 +37,48 @@ import java.time.LocalDateTime;
 public class UpdateActivityEvidenceByCurrentUserService implements UpdateActivityEvidenceByCurrentUserUseCase {
 
     private final EvidencePersistencePort evidencePersistencePort;
-    private final S3Port s3Port;
     private final ActivityEvidencePersistencePort activityEvidencePersistencePort;
+    private final S3Port s3Port;
+    private final ApplicationEventPublisher eventPublisher;
+    private final CurrentMemberProvider currentMemberProvider;
+    private final DiscordPort discordPort;
+    private final ApplicationEventPublisher applicationEventPublisher;
 
-    /**
-     * 활동 증빙자료를 수정합니다.
-     * <p>기존 증빙자료를 불러온 후 제목, 내용, 이미지 URL, 타입을 반영하여 수정합니다.
-     * <p>새 이미지가 첨부되면 기존 이미지는 삭제되며, 검토 상태는 {@code PENDING}으로 초기화됩니다.
-     * @param evidenceId 수정할 증빙자료 ID
-     * @param title 활동 제목
-     * @param content 활동 내용
-     * @param file 새 첨부 파일 (선택)
-     * @param evidenceType 증빙자료 유형
-     * @param imageUrl 이미지 URL (선택)
-     */
     @Override
-    public void execute(Long evidenceId, String title, String content, MultipartFile file, EvidenceType evidenceType, String imageUrl) {
+    public void execute(Long evidenceId, String title, String content, MultipartFile file, EvidenceType evidenceType) {
         Evidence evidence = evidencePersistencePort.findEvidenceByIdWithLock(evidenceId);
         ActivityEvidence activityEvidence = activityEvidencePersistencePort.findActivityEvidenceById(evidenceId);
+        String email = currentMemberProvider.getCurrentUser().getEmail();
 
-        String fileUrl = checkImageUrl(activityEvidence, imageUrl, file);
+        String fileUri = deleteAndUploadFile(activityEvidence, file, evidence.getEvidenceType(), email, evidenceId);
 
         Evidence newEvidence = createEvidence(evidence, evidenceType);
-        ActivityEvidence newActivityEvidence = createActivityEvidence(newEvidence, title, content, fileUrl);
+        ActivityEvidence newActivityEvidence = createActivityEvidence(newEvidence, title, content, fileUri);
 
         activityEvidencePersistencePort.saveActivityEvidence(newActivityEvidence);
+
+        applicationEventPublisher.publishEvent(new ScoreUpdatedEvent(email));
     }
 
-    /**
-     * 이미지 변경 여부를 판단하고 필요한 경우 기존 이미지를 삭제한 뒤 새 파일을 업로드합니다.
-     * @param activityEvidence 기존 활동 증빙자료
-     * @param imageUrl 요청된 이미지 URL
-     * @param file 업로드할 새 파일
-     * @return 최종 이미지 URL 또는 null
-     */
-    private String checkImageUrl(ActivityEvidence activityEvidence, String imageUrl, MultipartFile file) {
-        if (imageUrl != null
-                && !imageUrl.isEmpty()
-                && activityEvidence.getImageUrl().equals(imageUrl)) {
-            return imageUrl;
-        }
-
+    private String deleteAndUploadFile(ActivityEvidence activityEvidence, MultipartFile file, EvidenceType evidenceType, String email, Long evidenceId) {
         s3Port.deleteFile(activityEvidence.getImageUrl());
 
-        if (file != null && !file.isEmpty()){
-            return uploadFile(file);
-        } else {
-            return null;
+        try {
+            eventPublisher.publishEvent(new FileUploadEvent(
+                    evidenceId,
+                    file.getOriginalFilename(),
+                    file.getInputStream(),
+                    evidenceType,
+                    email
+            ));
+        } catch (IOException e) {
+            discordPort.sendEvidenceUploadFailureAlert(evidenceId, file.getOriginalFilename(), email, e);
+            throw new S3UploadFailedException();
         }
+        return "upload_" + file.getOriginalFilename() + "_" + UUID.randomUUID();
     }
 
-    /**
-     * 수정된 값으로 새로운 {@link ActivityEvidence} 객체를 생성합니다.
-     * @param evidence 연관 Evidence 객체
-     * @param title 제목
-     * @param content 내용
-     * @param fileUrl 이미지 URL
-     * @return 새로운 ActivityEvidence 객체
-     */
-    private ActivityEvidence createActivityEvidence(Evidence evidence, String title, String content, String fileUrl) {
-        return ActivityEvidence.builder()
-                .id(evidence)
-                .title(title)
-                .content(content)
-                .imageUrl(fileUrl)
-                .build();
-    }
 
-    /**
-     * 수정 사항을 반영하여 새로운 {@link Evidence} 객체를 생성합니다.
-     * <p>검토 상태는 항상 {@code PENDING}으로 초기화됩니다.
-     * @param evidence 기존 Evidence
-     * @param evidenceType 수정할 증빙자료 유형
-     * @return 수정된 Evidence 객체
-     */
     private Evidence createEvidence(Evidence evidence, EvidenceType evidenceType) {
         return Evidence.builder()
                 .id(evidence.getId())
@@ -116,20 +90,12 @@ public class UpdateActivityEvidenceByCurrentUserService implements UpdateActivit
                 .build();
     }
 
-    /**
-     * MultipartFile을 S3에 업로드하고 URL을 반환합니다.
-     * @param file 업로드할 파일
-     * @return 업로드된 이미지 URL
-     * @throws S3UploadFailedException 업로드 실패 시
-     */
-    private String uploadFile(MultipartFile file) {
-        try {
-            return s3Port.uploadFile(
-                    file.getOriginalFilename(),
-                    file.getInputStream()
-            ).join();
-        } catch (IOException e) {
-            throw new S3UploadFailedException();
-        }
+    private ActivityEvidence createActivityEvidence(Evidence evidence, String title, String content, String fileUrl) {
+        return ActivityEvidence.builder()
+                .id(evidence)
+                .title(title)
+                .content(content)
+                .imageUrl(fileUrl)
+                .build();
     }
 }

--- a/src/main/java/team/incude/gsmc/v2/domain/evidence/application/usecase/service/UpdateEvidenceFileService.java
+++ b/src/main/java/team/incude/gsmc/v2/domain/evidence/application/usecase/service/UpdateEvidenceFileService.java
@@ -7,14 +7,18 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import team.incude.gsmc.v2.domain.evidence.application.port.ActivityEvidencePersistencePort;
+import team.incude.gsmc.v2.domain.evidence.application.port.DiscordPort;
 import team.incude.gsmc.v2.domain.evidence.application.port.OtherEvidencePersistencePort;
 import team.incude.gsmc.v2.domain.evidence.application.port.S3Port;
 import team.incude.gsmc.v2.domain.evidence.application.usecase.UpdateEvidenceFileUseCase;
 import team.incude.gsmc.v2.domain.evidence.domain.ActivityEvidence;
 import team.incude.gsmc.v2.domain.evidence.domain.OtherEvidence;
 import team.incude.gsmc.v2.domain.evidence.domain.constant.EvidenceType;
+import team.incude.gsmc.v2.global.thirdparty.aws.exception.S3UploadFailedException;
 
 import java.io.InputStream;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutionException;
 
 @Service
 @RequiredArgsConstructor
@@ -26,42 +30,52 @@ public class UpdateEvidenceFileService implements UpdateEvidenceFileUseCase {
     private final ActivityEvidencePersistencePort activityEvidencePersistencePort;
     private final OtherEvidencePersistencePort otherEvidencePersistencePort;
     private final RetryTemplate retryTemplate;
+    private final DiscordPort discordPort;
 
     @Override
-    public void execute(Long evidenceId, String fileName, InputStream inputStream, EvidenceType evidenceType) {
-        String fileUrl = uploadFile(fileName, inputStream);
+    public void execute(Long evidenceId, String fileName, InputStream inputStream, EvidenceType evidenceType, String email) {
+        String fileUrl;
+
+        fileUrl = retryTemplate.execute(context -> {
+            try {
+                return s3Port.uploadFile(fileName, inputStream).get();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                discordPort.sendEvidenceUploadFailureAlert(
+                        evidenceId,
+                        fileName,
+                        email,
+                        e
+                );
+                throw new S3UploadFailedException();
+            } catch (ExecutionException e) {
+                discordPort.sendEvidenceUploadFailureAlert(
+                        evidenceId,
+                        fileName,
+                        email,
+                        e
+                );
+                throw new S3UploadFailedException();
+            }
+        });
 
         switch (evidenceType) {
             case MAJOR, HUMANITIES -> {
                 ActivityEvidence ae = activityEvidencePersistencePort.findActivityEvidenceById(evidenceId);
-
-                activityEvidencePersistencePort.saveActivityEvidence(ae.getId(), updateActivityEvidence(ae, fileUrl));
+                activityEvidencePersistencePort.saveActivityEvidence(ae.getId(), ActivityEvidence.builder()
+                        .id(ae.getId())
+                        .title(ae.getTitle())
+                        .imageUrl(fileUrl)
+                        .content(ae.getContent())
+                        .build());
             }
             default -> {
                 OtherEvidence oe = otherEvidencePersistencePort.findOtherEvidenceById(evidenceId);
-
-                otherEvidencePersistencePort.saveOtherEvidence(oe.getId(), updateOtherEvidence(oe, fileUrl));
+                otherEvidencePersistencePort.saveOtherEvidence(oe.getId(), OtherEvidence.builder()
+                        .id(oe.getId())
+                        .fileUri(fileUrl)
+                        .build());
             }
         }
-    }
-
-    private String uploadFile(String fileName, InputStream inputStream) {
-        return retryTemplate.execute(context -> s3Port.uploadFile(fileName, inputStream).join());
-    }
-
-    private ActivityEvidence updateActivityEvidence(ActivityEvidence activityEvidence, String fileUrl) {
-        return ActivityEvidence.builder()
-                .id(activityEvidence.getId())
-                .title(activityEvidence.getTitle())
-                .imageUrl(fileUrl)
-                .content(activityEvidence.getContent())
-                .build();
-    }
-
-    private OtherEvidence updateOtherEvidence(OtherEvidence otherEvidence, String fileUrl) {
-        return OtherEvidence.builder()
-                .id(otherEvidence.getId())
-                .fileUri(fileUrl)
-                .build();
     }
 }

--- a/src/main/java/team/incude/gsmc/v2/domain/evidence/domain/RetryUploadCommand.java
+++ b/src/main/java/team/incude/gsmc/v2/domain/evidence/domain/RetryUploadCommand.java
@@ -1,0 +1,21 @@
+package team.incude.gsmc.v2.domain.evidence.domain;
+
+import lombok.Builder;
+import lombok.Getter;
+import team.incude.gsmc.v2.domain.evidence.domain.constant.EvidenceType;
+
+/**
+ * 재시도 업로드 커맨드 객체
+ * 재시도 큐에 들어가는 파일 업로드 명령을 캡슐화합니다.
+ * author suuuuuuminnnnnn
+ */
+@Getter
+@Builder
+public class RetryUploadCommand {
+    private final String commandId;
+    private final Long evidenceId;
+    private final String fileName;
+    private final String tempFilePath;
+    private final EvidenceType evidenceType;
+    private final String email;
+}

--- a/src/main/java/team/incude/gsmc/v2/domain/evidence/presentation/EvidenceWebAdapter.java
+++ b/src/main/java/team/incude/gsmc/v2/domain/evidence/presentation/EvidenceWebAdapter.java
@@ -125,7 +125,7 @@ public class EvidenceWebAdapter {
     public ResponseEntity<Void> patchMajorEvidence(
             @PathVariable Long evidenceId,
             @Valid @ModelAttribute PatchActivityEvidenceRequest request) {
-        evidenceApplicationPort.updateMajorEvidenceByCurrentUser(evidenceId, request.title(), request.content(), request.file(), request.imageUrl());
+        evidenceApplicationPort.updateMajorEvidenceByCurrentUser(evidenceId, request.title(), request.content(), request.file());
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 
@@ -139,7 +139,7 @@ public class EvidenceWebAdapter {
     public ResponseEntity<Void> patchHumanityEvidence(
             @PathVariable Long evidenceId,
             @Valid @ModelAttribute PatchActivityEvidenceRequest request) {
-        evidenceApplicationPort.updateHumanitiesEvidenceByCurrentUser(evidenceId, request.title(), request.content(), request.file(), request.imageUrl());
+        evidenceApplicationPort.updateHumanitiesEvidenceByCurrentUser(evidenceId, request.title(), request.content(), request.file());
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 
@@ -167,7 +167,7 @@ public class EvidenceWebAdapter {
     public ResponseEntity<Void> patchOtherEvidence(
             @PathVariable Long evidenceId,
             @ModelAttribute PatchOtherEvidenceRequest request) {
-        evidenceApplicationPort.updateOtherEvidenceByCurrentUser(evidenceId, request.file(), request.imageUrl());
+        evidenceApplicationPort.updateOtherEvidenceByCurrentUser(evidenceId, request.file());
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 
@@ -181,7 +181,7 @@ public class EvidenceWebAdapter {
     public ResponseEntity<Void> patchScoringEvidence(
             @PathVariable Long evidenceId,
             @ModelAttribute PatchOtherScoringEvidenceRequest request) {
-        evidenceApplicationPort.updateOtherScoringEvidenceByCurrentUser(evidenceId, request.file(), request.value(), request.imageUrl());
+        evidenceApplicationPort.updateOtherScoringEvidenceByCurrentUser(evidenceId, request.file(), request.value());
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 

--- a/src/main/java/team/incude/gsmc/v2/domain/evidence/presentation/data/FileUploadRetryMessageDto.java
+++ b/src/main/java/team/incude/gsmc/v2/domain/evidence/presentation/data/FileUploadRetryMessageDto.java
@@ -1,0 +1,19 @@
+package team.incude.gsmc.v2.domain.evidence.presentation.data;
+
+import lombok.Builder;
+import team.incude.gsmc.v2.domain.evidence.domain.constant.EvidenceType;
+
+/**
+ * 파일 업로드 재시도 메시지 DTO
+ * 재시도 큐에 저장 및 처리되는 재시도 메시지의 데이터를 담습니다.
+ * author suuuuuuminnnnnn
+ */
+@Builder
+public record FileUploadRetryMessageDto(
+        String commandId,
+        Long evidenceId,
+        String fileName,
+        String tempFilePath,
+        EvidenceType evidenceType,
+        String email
+) {}

--- a/src/main/java/team/incude/gsmc/v2/domain/evidence/presentation/data/request/PatchActivityEvidenceRequest.java
+++ b/src/main/java/team/incude/gsmc/v2/domain/evidence/presentation/data/request/PatchActivityEvidenceRequest.java
@@ -1,5 +1,6 @@
 package team.incude.gsmc.v2.domain.evidence.presentation.data.request;
 
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -8,14 +9,12 @@ import org.springframework.web.multipart.MultipartFile;
  * <p>제목, 내용, 파일 또는 이미지 URL을 수정할 수 있으며, 기존 증빙자료에 대한 내용을 변경할 때 사용됩니다.
  * @param title 수정할 제목 (최대 100자)
  * @param content 수정할 내용 (최대 1500자)
- * @param file 새로 업로드할 파일 (선택)
- * @param imageUrl 이미지 URL (선택)
+ * @param file 새로 업로드할 파일
  * @author suuuuuuminnnnnn
  */
 public record PatchActivityEvidenceRequest(
         @Size(max = 100) String title,
         @Size(max = 1500) String content,
-        MultipartFile file,
-        String imageUrl
+        @NotNull MultipartFile file
 ) {
 }

--- a/src/main/java/team/incude/gsmc/v2/domain/evidence/presentation/data/request/PatchActivityEvidenceRequest.java
+++ b/src/main/java/team/incude/gsmc/v2/domain/evidence/presentation/data/request/PatchActivityEvidenceRequest.java
@@ -15,6 +15,6 @@ import org.springframework.web.multipart.MultipartFile;
 public record PatchActivityEvidenceRequest(
         @Size(max = 100) String title,
         @Size(max = 1500) String content,
-        @NotNull MultipartFile file
+        MultipartFile file
 ) {
 }

--- a/src/main/java/team/incude/gsmc/v2/domain/evidence/presentation/data/request/PatchOtherEvidenceRequest.java
+++ b/src/main/java/team/incude/gsmc/v2/domain/evidence/presentation/data/request/PatchOtherEvidenceRequest.java
@@ -1,18 +1,17 @@
 package team.incude.gsmc.v2.domain.evidence.presentation.data.request;
 
+import jakarta.validation.constraints.NotNull;
 import org.springframework.web.multipart.MultipartFile;
 
 /**
  * 기타 증빙자료 수정을 위한 요청 DTO입니다.
  * <p>파일 또는 이미지 URL을 새로 지정하여 기존 기타 증빙자료를 수정할 때 사용됩니다.
  * <p>두 필드는 선택적이며, 둘 중 하나 이상이 존재해야 합니다.
- * @param file 새로 첨부할 증빙자료 파일 (선택)
- * @param imageUrl 대체할 이미지 URL (선택)
+ * @param file 새로 첨부할 증빙자료 파일
  * @author suuuuuuminnnnnn
  */
 
 public record PatchOtherEvidenceRequest(
-        MultipartFile file,
-        String imageUrl
+        @NotNull MultipartFile file
 ) {
 }

--- a/src/main/java/team/incude/gsmc/v2/domain/evidence/presentation/data/request/PatchOtherEvidenceRequest.java
+++ b/src/main/java/team/incude/gsmc/v2/domain/evidence/presentation/data/request/PatchOtherEvidenceRequest.java
@@ -1,7 +1,7 @@
 package team.incude.gsmc.v2.domain.evidence.presentation.data.request;
 
-import jakarta.validation.constraints.NotNull;
 import org.springframework.web.multipart.MultipartFile;
+import team.incude.gsmc.v2.global.annotation.validator.NotEmptyFile;
 
 /**
  * 기타 증빙자료 수정을 위한 요청 DTO입니다.
@@ -12,6 +12,6 @@ import org.springframework.web.multipart.MultipartFile;
  */
 
 public record PatchOtherEvidenceRequest(
-        @NotNull MultipartFile file
+        @NotEmptyFile MultipartFile file
 ) {
 }

--- a/src/main/java/team/incude/gsmc/v2/domain/evidence/presentation/data/request/PatchOtherScoringEvidenceRequest.java
+++ b/src/main/java/team/incude/gsmc/v2/domain/evidence/presentation/data/request/PatchOtherScoringEvidenceRequest.java
@@ -1,5 +1,6 @@
 package team.incude.gsmc.v2.domain.evidence.presentation.data.request;
 
+import jakarta.validation.constraints.NotNull;
 import org.springframework.web.multipart.MultipartFile;
 
 /**
@@ -7,13 +8,11 @@ import org.springframework.web.multipart.MultipartFile;
  * <p>점수 값, 파일, 이미지 URL을 수정할 수 있으며, 기존 증빙자료의 내용을 갱신할 때 사용됩니다.
  * <p>세 필드는 모두 선택적으로 입력 가능하며, 변경이 필요한 항목만 전달하면 됩니다.
  * @param value 새로운 점수 값 (선택)
- * @param file 새로 첨부할 증빙자료 파일 (선택)
- * @param imageUrl 대체할 이미지 URL (선택)
+ * @param file 새로 첨부할 증빙자료 파일
  * @author suuuuuuminnnnnn
  */
 public record PatchOtherScoringEvidenceRequest(
-        Integer value,
-        MultipartFile file,
-        String imageUrl
+        @NotNull Integer value,
+        @NotNull MultipartFile file
 ) {
 }

--- a/src/main/java/team/incude/gsmc/v2/domain/evidence/presentation/data/request/PatchOtherScoringEvidenceRequest.java
+++ b/src/main/java/team/incude/gsmc/v2/domain/evidence/presentation/data/request/PatchOtherScoringEvidenceRequest.java
@@ -2,6 +2,7 @@ package team.incude.gsmc.v2.domain.evidence.presentation.data.request;
 
 import jakarta.validation.constraints.NotNull;
 import org.springframework.web.multipart.MultipartFile;
+import team.incude.gsmc.v2.global.annotation.validator.NotEmptyFile;
 
 /**
  * 점수 기반 기타 증빙자료 수정을 위한 요청 DTO입니다.
@@ -13,6 +14,6 @@ import org.springframework.web.multipart.MultipartFile;
  */
 public record PatchOtherScoringEvidenceRequest(
         @NotNull Integer value,
-        @NotNull MultipartFile file
+        @NotEmptyFile MultipartFile file
 ) {
 }

--- a/src/main/java/team/incude/gsmc/v2/global/event/FileUploadEvent.java
+++ b/src/main/java/team/incude/gsmc/v2/global/event/FileUploadEvent.java
@@ -8,6 +8,7 @@ public record FileUploadEvent(
         Long evidenceId,
         String fileName,
         InputStream inputStream,
-        EvidenceType evidenceType
+        EvidenceType evidenceType,
+        String email
 ) {
 }

--- a/src/main/java/team/incude/gsmc/v2/global/event/handler/FileUploadEventListener.java
+++ b/src/main/java/team/incude/gsmc/v2/global/event/handler/FileUploadEventListener.java
@@ -18,6 +18,6 @@ public class FileUploadEventListener {
     @Async
     @TransactionalEventListener(phase = AFTER_COMMIT)
     public void handleFileUploadEvent(FileUploadEvent event) {
-        evidenceApplicationPort.updateEvidenceFile(event.evidenceId(), event.fileName(), event.inputStream(), event.evidenceType());
+        evidenceApplicationPort.updateEvidenceFile(event.evidenceId(), event.fileName(), event.inputStream(), event.evidenceType(), event.email());
     }
 }

--- a/src/main/java/team/incude/gsmc/v2/global/redis/RedisAdapter.java
+++ b/src/main/java/team/incude/gsmc/v2/global/redis/RedisAdapter.java
@@ -1,0 +1,33 @@
+package team.incude.gsmc.v2.global.redis;
+
+import lombok.RequiredArgsConstructor;
+import team.incude.gsmc.v2.domain.evidence.application.port.RedisPort;
+import team.incude.gsmc.v2.domain.evidence.application.usecase.RetryFileUploadUseCase;
+import team.incude.gsmc.v2.domain.evidence.domain.RetryUploadCommand;
+import team.incude.gsmc.v2.global.annotation.PortDirection;
+import team.incude.gsmc.v2.global.annotation.adapter.Adapter;
+
+import java.io.InputStream;
+
+/**
+ * Redis 재시도 큐 관련 INBOUND 어댑터입니다.
+ * {@link RetryFileUploadUseCase}를 호출하여 재시도 메시지를 큐에 등록합니다.
+ * author suuuuuuminnnnnn
+ */
+@Adapter(direction = PortDirection.INBOUND)
+@RequiredArgsConstructor
+public class RedisAdapter implements RedisPort {
+
+    private final RetryFileUploadUseCase retryFileUploadUseCase;
+
+    /**
+     * Redis 재시도 큐에 재시도 명령과 파일 입력 스트림을 등록합니다.
+     * @param command 재시도 명령 데이터
+     * @param inputStream 파일 입력 스트림
+     * @param retryTimeMillis 재시도 예정 시간 (밀리초 단위)
+     */
+    @Override
+    public void scheduleRetry(RetryUploadCommand command, InputStream inputStream, long retryTimeMillis) {
+        retryFileUploadUseCase.execute(command, inputStream, retryTimeMillis);
+    }
+}

--- a/src/main/java/team/incude/gsmc/v2/global/redis/RetryUploadZSetAdapter.java
+++ b/src/main/java/team/incude/gsmc/v2/global/redis/RetryUploadZSetAdapter.java
@@ -1,0 +1,103 @@
+package team.incude.gsmc.v2.global.redis;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+import team.incude.gsmc.v2.domain.evidence.application.port.RetryUploadZSetPort;
+import team.incude.gsmc.v2.domain.evidence.presentation.data.FileUploadRetryMessageDto;
+import team.incude.gsmc.v2.global.annotation.PortDirection;
+import team.incude.gsmc.v2.global.annotation.adapter.Adapter;
+import team.incude.gsmc.v2.global.thirdparty.aws.exception.S3UploadFailedException;
+
+import java.time.Instant;
+import java.util.Collections;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Redis Sorted Set을 활용하여 파일 업로드 재시도 메시지를 관리하는 어댑터입니다.
+ * <p>재시도 메시지를 직렬화하여 Redis의 ZSet에 저장하고, 재시도 시간 기준으로
+ * 메시지를 조회 및 삭제하는 기능을 제공합니다.
+ * <p>{@link RetryUploadZSetPort} 인터페이스를 구현하며, 아웃바운드 포트 역할을 수행합니다.
+ *
+ * @author suuuuuuminnnnnn
+ */
+@Adapter(direction = PortDirection.OUTBOUND)
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class RetryUploadZSetAdapter implements RetryUploadZSetPort {
+
+    private final RedisTemplate<String, String> redisTemplate;
+    private final ObjectMapper objectMapper;
+
+    private static final String RETRY_ZSET_KEY = "retry:file:upload:zset";
+
+    /**
+     * Redis ZSet에 재시도 메시지를 등록합니다.
+     * @param message 재시도할 파일 업로드 메시지 DTO
+     * @param retryTimeMillis 재시도 예정 시간(밀리초 단위)
+     * @throws S3UploadFailedException 메시지 직렬화 실패 시 발생
+     */
+    @Override
+    public void scheduleRetry(FileUploadRetryMessageDto message, long retryTimeMillis) {
+        try {
+            String serialized = objectMapper.writeValueAsString(message);
+            redisTemplate.opsForZSet().add(RETRY_ZSET_KEY, serialized, retryTimeMillis);
+            log.info("재시도 메시지 큐 등록 완료: {} (재시도 시간: {})", message.commandId(), Instant.ofEpochMilli(retryTimeMillis));
+        } catch (JsonProcessingException e) {
+            log.error("파일 재시도 메시지 직렬화 실패", e);
+            throw new S3UploadFailedException();
+        }
+    }
+
+    /**
+     * 재시도 예정 시간까지 도달한 메시지를 조회합니다.
+     * @param nowMillis 현재 시간(밀리초 단위)
+     * @return 재시도 준비가 된 메시지 집합
+     */
+    @Override
+    public Set<FileUploadRetryMessageDto> pollReadyToRetry(long nowMillis) {
+        try {
+            Set<String> serializedSet = redisTemplate.opsForZSet()
+                    .rangeByScore(RETRY_ZSET_KEY, 0, nowMillis);
+
+            if (serializedSet == null || serializedSet.isEmpty()) {
+                return Collections.emptySet();
+            }
+
+            return serializedSet.stream()
+                    .map(s -> {
+                        try {
+                            return objectMapper.readValue(s, FileUploadRetryMessageDto.class);
+                        } catch (JsonProcessingException e) {
+                            log.warn("재시도 메시지 역직렬화 실패, 해당 메시지 스킵: {}", s, e);
+                            return null;
+                        }
+                    })
+                    .filter(dto -> dto != null)
+                    .collect(Collectors.toSet());
+        } catch (Exception e) {
+            log.error("재시도 메시지 조회 중 오류 발생", e);
+            return Collections.emptySet();
+        }
+    }
+
+    /**
+     * 재시도 큐에서 특정 메시지를 삭제합니다.
+     * @param message 삭제할 재시도 메시지 DTO
+     */
+    @Override
+    public void removeMessage(FileUploadRetryMessageDto message) {
+        try {
+            String serialized = objectMapper.writeValueAsString(message);
+            redisTemplate.opsForZSet().remove(RETRY_ZSET_KEY, serialized);
+            log.info("재시도 메시지 삭제 완료: {}", message.commandId());
+        } catch (JsonProcessingException e) {
+            log.warn("재시도 메시지 삭제 중 직렬화 실패: {}", message.commandId(), e);
+        }
+    }
+}

--- a/src/main/java/team/incude/gsmc/v2/global/redis/config/RedisConfig.java
+++ b/src/main/java/team/incude/gsmc/v2/global/redis/config/RedisConfig.java
@@ -1,0 +1,38 @@
+package team.incude.gsmc.v2.global.redis.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(host, port);
+    }
+
+    @Bean
+    public RedisTemplate<String, String> redisTemplate() {
+        RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+        redisTemplate.setHashKeySerializer(new StringRedisSerializer());
+        redisTemplate.setHashValueSerializer(new StringRedisSerializer());
+
+        redisTemplate.afterPropertiesSet();
+        return redisTemplate;
+    }
+}

--- a/src/main/java/team/incude/gsmc/v2/global/redis/config/RedisConfig.java
+++ b/src/main/java/team/incude/gsmc/v2/global/redis/config/RedisConfig.java
@@ -8,6 +8,15 @@ import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactor
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
+/**
+ * Redis 관련 설정을 정의하는 구성 클래스입니다.
+ * <p>Lettuce 기반 RedisConnectionFactory를 생성하고,
+ * 문자열 기반 직렬화를 사용하는 {@link RedisTemplate}을 빈으로 등록합니다.</p>
+ * <p>이 설정을 통해 Redis에 문자열 키-값 데이터를 저장하거나 조회할 수 있습니다.</p>
+ * <p>host와 port는 application.yml 또는 application.properties의
+ * {@code spring.data.redis.host}, {@code spring.data.redis.port}에서 주입됩니다.</p>
+ * @author suuuuuuminnnnnn
+ */
 @Configuration
 public class RedisConfig {
 

--- a/src/main/java/team/incude/gsmc/v2/global/redis/mapper/RetryUploadMapper.java
+++ b/src/main/java/team/incude/gsmc/v2/global/redis/mapper/RetryUploadMapper.java
@@ -1,0 +1,31 @@
+package team.incude.gsmc.v2.global.redis.mapper;
+
+import org.springframework.stereotype.Component;
+import team.incude.gsmc.v2.domain.evidence.domain.RetryUploadCommand;
+import team.incude.gsmc.v2.domain.evidence.presentation.data.FileUploadRetryMessageDto;
+
+@Component
+public class RetryUploadMapper {
+
+    public FileUploadRetryMessageDto toMessage(RetryUploadCommand command) {
+        return FileUploadRetryMessageDto.builder()
+                .commandId(command.getCommandId())
+                .evidenceId(command.getEvidenceId())
+                .fileName(command.getFileName())
+                .tempFilePath(command.getTempFilePath())
+                .evidenceType(command.getEvidenceType())
+                .email(command.getEmail())
+                .build();
+    }
+
+    public RetryUploadCommand toDomain(FileUploadRetryMessageDto message) {
+        return RetryUploadCommand.builder()
+                .commandId(message.commandId())
+                .evidenceId(message.evidenceId())
+                .fileName(message.fileName())
+                .tempFilePath(message.tempFilePath())
+                .evidenceType(message.evidenceType())
+                .email(message.email())
+                .build();
+    }
+}

--- a/src/main/java/team/incude/gsmc/v2/global/util/InputStreamUtil.java
+++ b/src/main/java/team/incude/gsmc/v2/global/util/InputStreamUtil.java
@@ -1,0 +1,42 @@
+package team.incude.gsmc.v2.global.util;
+
+import lombok.experimental.UtilityClass;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * InputStream 관련 유틸리티 메서드를 제공하는 클래스입니다.
+ * <p>{@link InputStream}은 기본적으로 한 번만 읽을 수 있기 때문에,
+ * 동일한 데이터를 여러 번 사용하기 위해 복제 기능을 제공합니다.
+ * <p>{@code @UtilityClass}로 선언되어 정적 메서드만 포함하며 인스턴스화할 수 없습니다.
+ *
+ * <p>주로 S3 업로드 실패 시 재시도 처리 등을 위해 {@link InputStream}을 임시로 복제하는 데 사용됩니다.
+ *
+ * @author suuuuuuminnnnnn
+ */
+@UtilityClass
+public class InputStreamUtil {
+
+    /**
+     * 주어진 InputStream을 읽고 동일한 내용을 갖는 새로운 {@link ByteArrayInputStream}으로 반환합니다.
+     * <p>원본 InputStream은 소모되며, 복제된 스트림은 이후 재사용이 가능합니다.
+     *
+     * @param inputStream 복제할 InputStream
+     * @return 복제된 ByteArrayInputStream
+     * @throws IOException InputStream을 읽는 도중 문제가 발생한 경우
+     */
+    public static ByteArrayInputStream duplicate(InputStream inputStream) throws IOException {
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
+            byte[] buffer = new byte[8192];
+            int read;
+            while ((read = inputStream.read(buffer)) != -1) {
+                baos.write(buffer, 0, read);
+            }
+            byte[] bytes = baos.toByteArray();
+            return new ByteArrayInputStream(bytes);
+        }
+    }
+}

--- a/src/test/java/team/incude/gsmc/v2/domain/RetryFileUploadConsumerTest.java
+++ b/src/test/java/team/incude/gsmc/v2/domain/RetryFileUploadConsumerTest.java
@@ -1,0 +1,65 @@
+package team.incude.gsmc.v2.domain;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import team.incude.gsmc.v2.domain.evidence.application.consumer.RetryFileUploadConsumer;
+import team.incude.gsmc.v2.domain.evidence.application.port.EvidenceApplicationPort;
+import team.incude.gsmc.v2.domain.evidence.application.port.RetryUploadZSetPort;
+import team.incude.gsmc.v2.domain.evidence.domain.constant.EvidenceType;
+import team.incude.gsmc.v2.domain.evidence.presentation.data.FileUploadRetryMessageDto;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.util.Set;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class RetryFileUploadConsumerTest {
+
+    @Mock
+    private RetryUploadZSetPort retryUploadZSetPort;
+
+    @Mock
+    private EvidenceApplicationPort evidenceApplicationPort;
+
+    @InjectMocks
+    private RetryFileUploadConsumer retryFileUploadConsumer;
+
+    @Test
+    void 임시파일이_존재하면_업로드하고_큐에서_제거한다() throws Exception {
+        // given
+        String tempFilePath = File.createTempFile("test-", ".txt").getAbsolutePath();
+        try (FileOutputStream fos = new FileOutputStream(tempFilePath)) {
+            fos.write("mock-data".getBytes());
+        }
+
+        FileUploadRetryMessageDto dto = new FileUploadRetryMessageDto(
+                "cmd-id",
+                1L,
+                "mock.txt",
+                tempFilePath,
+                EvidenceType.MAJOR,
+                "test@gsm.hs.kr"
+        );
+
+        when(retryUploadZSetPort.pollReadyToRetry(anyLong()))
+                .thenReturn(Set.of(dto));
+
+        RetryFileUploadConsumer consumer = new RetryFileUploadConsumer(retryUploadZSetPort, evidenceApplicationPort);
+
+        // when
+        consumer.consume();
+
+        // then
+        verify(evidenceApplicationPort, times(1))
+                .updateEvidenceFile(eq(1L), eq("mock.txt"), any(), eq(EvidenceType.MAJOR), eq("test@gsm.hs.kr"));
+
+        verify(retryUploadZSetPort, times(1)).removeMessage(eq(dto));
+    }
+}

--- a/src/test/java/team/incude/gsmc/v2/domain/RetryFileUploadServiceTest.java
+++ b/src/test/java/team/incude/gsmc/v2/domain/RetryFileUploadServiceTest.java
@@ -1,0 +1,56 @@
+package team.incude.gsmc.v2.domain;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import team.incude.gsmc.v2.domain.evidence.application.usecase.service.RetryFileUploadService;
+import team.incude.gsmc.v2.domain.evidence.domain.RetryUploadCommand;
+import team.incude.gsmc.v2.domain.evidence.domain.constant.EvidenceType;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.util.Set;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class RetryFileUploadServiceTest {
+
+    @Autowired
+    private RetryFileUploadService retryFileUploadService;
+
+    @Autowired
+    private RedisTemplate<String, String> redisTemplate;
+
+    private static final String RETRY_ZSET_KEY = "retry:file:upload:zset";
+
+    @Test
+    void 파일을_임시파일로_복사하고_ZSet에_등록한다() {
+        // given
+        RetryUploadCommand command = RetryUploadCommand.builder()
+                .commandId(UUID.randomUUID().toString())
+                .evidenceId(123L)
+                .fileName("mock.txt")
+                .evidenceType(EvidenceType.MAJOR)
+                .email("tester@gsm.hs.kr")
+                .build();
+
+        byte[] mockData = "hello world".getBytes();
+        InputStream inputStream = new ByteArrayInputStream(mockData);
+        long now = System.currentTimeMillis();
+        long delayMillis = 2000L;
+
+        // when
+        retryFileUploadService.execute(command, inputStream, delayMillis);
+
+        // then
+        Set<String> queuedMessages = redisTemplate.opsForZSet()
+                .rangeByScore(RETRY_ZSET_KEY, now, now + delayMillis + 1000);
+
+        assertThat(queuedMessages).isNotEmpty();
+    }
+}


### PR DESCRIPTION
## 📋 작업 내용
> 증빙자료 업로드 이벤트 실패 시 메세지 큐를 이용해서 재시도하는 서비스 클래스를 추가하였고 증빙자료 수정 서비스 클래스의 수정 로직을 변경하였습니다

## 🤝 리뷰 시 참고사항

## ✅ 체크리스트
> 추가적으로 필요한 체크리스트가 있다면 추가적으로 작성해주세요.
- [x] 이 작업으로 인해 변경이 필요한 문서를 작성 또는 수정했나요? (e.g. `README`, `.env.example`)
- [x] 작업한 코드가 정상적으로 동작하는지 확인했나요?
- [ ] 작업한 코드에 대한 테스트 코드를 작성하거나 수정했나요?
- [x] Merge 대상 브랜치를 올바르게 설정했나요?
- [x] 해당 PR과 관련 없는 작업이 포함되지는 않았나요?
- [ ] PR의 올바른 라벨과 리뷰어를 설정했나요?