### PR TITLE
Redis 포트 노출관련 설정 누락 문제 해결

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -11,7 +11,7 @@ services:
   redis:
     image: 'redis:latest'
     ports:
-      - '6379'
+      - '6379:6379'
   prometheus:
     image: prom/prometheus
     ports:


### PR DESCRIPTION
## 📋 작업 내용
> 로컬 개발환경을 위한 ``compose.yaml``에서 Redis 컨테이너의 포트가 노출되도록 설정되어 있지 않아 연결에 실패하던 문제를 해결하였습니다

## 🤝 리뷰 시 참고사항
> #154 이 PR에서 수정된건지 어디서 수정된건지는 모르겠지만 되돌려놨습니다

## ✅ 체크리스트
- [x] 이 작업으로 인해 변경이 필요한 문서를 작성 또는 수정했나요? (e.g. `README`, `.env.example`)
- [x] 작업한 코드가 정상적으로 동작하는지 확인했나요?
- [x] 작업한 코드에 대한 테스트 코드를 작성하거나 수정했나요?
- [x] Merge 대상 브랜치를 올바르게 설정했나요?
- [x] 해당 PR과 관련 없는 작업이 포함되지는 않았나요?
- [x] PR의 올바른 라벨과 리뷰어를 설정했나요?