### PR TITLE
자격증 모델 패키지명 오탈자 수정

### DIFF
--- a/src/main/java/team/incube/gsmc/v2/domain/certificate/application/CertificateApplicationAdapter.java
+++ b/src/main/java/team/incube/gsmc/v2/domain/certificate/application/CertificateApplicationAdapter.java
@@ -7,7 +7,7 @@ import team.incube.gsmc.v2.domain.certificate.application.usecase.CreateCertific
 import team.incube.gsmc.v2.domain.certificate.application.usecase.DeleteCertificateUseCase;
 import team.incube.gsmc.v2.domain.certificate.application.usecase.FindCertificateUseCase;
 import team.incube.gsmc.v2.domain.certificate.application.usecase.UpdateCurrentCertificateUseCase;
-import team.incube.gsmc.v2.domain.certificate.persentation.data.response.GetCertificateResponse;
+import team.incube.gsmc.v2.domain.certificate.presentation.data.response.GetCertificateResponse;
 import team.incube.gsmc.v2.global.annotation.PortDirection;
 import team.incube.gsmc.v2.global.annotation.adapter.Adapter;
 

--- a/src/main/java/team/incube/gsmc/v2/domain/certificate/application/port/CertificateApplicationPort.java
+++ b/src/main/java/team/incube/gsmc/v2/domain/certificate/application/port/CertificateApplicationPort.java
@@ -1,7 +1,7 @@
 package team.incube.gsmc.v2.domain.certificate.application.port;
 
 import org.springframework.web.multipart.MultipartFile;
-import team.incube.gsmc.v2.domain.certificate.persentation.data.response.GetCertificateResponse;
+import team.incube.gsmc.v2.domain.certificate.presentation.data.response.GetCertificateResponse;
 import team.incube.gsmc.v2.global.annotation.PortDirection;
 import team.incube.gsmc.v2.global.annotation.port.Port;
 

--- a/src/main/java/team/incube/gsmc/v2/domain/certificate/application/usecase/FindCertificateUseCase.java
+++ b/src/main/java/team/incube/gsmc/v2/domain/certificate/application/usecase/FindCertificateUseCase.java
@@ -1,6 +1,6 @@
 package team.incube.gsmc.v2.domain.certificate.application.usecase;
 
-import team.incube.gsmc.v2.domain.certificate.persentation.data.response.GetCertificateResponse;
+import team.incube.gsmc.v2.domain.certificate.presentation.data.response.GetCertificateResponse;
 
 /**
  * 자격증 조회 기능을 제공하는 인터페이스입니다.

--- a/src/main/java/team/incube/gsmc/v2/domain/certificate/application/usecase/service/FindCertificateService.java
+++ b/src/main/java/team/incube/gsmc/v2/domain/certificate/application/usecase/service/FindCertificateService.java
@@ -5,8 +5,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import team.incube.gsmc.v2.domain.certificate.application.port.CertificatePersistencePort;
 import team.incube.gsmc.v2.domain.certificate.application.usecase.FindCertificateUseCase;
-import team.incube.gsmc.v2.domain.certificate.persentation.data.GetCertificateDto;
-import team.incube.gsmc.v2.domain.certificate.persentation.data.response.GetCertificateResponse;
+import team.incube.gsmc.v2.domain.certificate.presentation.data.GetCertificateDto;
+import team.incube.gsmc.v2.domain.certificate.presentation.data.response.GetCertificateResponse;
 import team.incube.gsmc.v2.domain.member.application.port.StudentDetailPersistencePort;
 import team.incube.gsmc.v2.global.security.jwt.application.usecase.service.CurrentMemberProvider;
 

--- a/src/main/java/team/incube/gsmc/v2/domain/certificate/presentation/CertificateWebAdapter.java
+++ b/src/main/java/team/incube/gsmc/v2/domain/certificate/presentation/CertificateWebAdapter.java
@@ -1,14 +1,14 @@
-package team.incube.gsmc.v2.domain.certificate.persentation;
+package team.incube.gsmc.v2.domain.certificate.presentation;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import team.incube.gsmc.v2.domain.certificate.persentation.data.request.CreateCertificateRequest;
+import team.incube.gsmc.v2.domain.certificate.presentation.data.request.CreateCertificateRequest;
 import team.incube.gsmc.v2.domain.certificate.application.port.CertificateApplicationPort;
-import team.incube.gsmc.v2.domain.certificate.persentation.data.request.PatchCertificateRequest;
-import team.incube.gsmc.v2.domain.certificate.persentation.data.response.GetCertificateResponse;
+import team.incube.gsmc.v2.domain.certificate.presentation.data.request.PatchCertificateRequest;
+import team.incube.gsmc.v2.domain.certificate.presentation.data.response.GetCertificateResponse;
 
 /**
  * 자격증 관련 HTTP 요청을 처리하는 Web 어댑터 클래스입니다.

--- a/src/main/java/team/incube/gsmc/v2/domain/certificate/presentation/data/GetCertificateDto.java
+++ b/src/main/java/team/incube/gsmc/v2/domain/certificate/presentation/data/GetCertificateDto.java
@@ -1,4 +1,4 @@
-package team.incube.gsmc.v2.domain.certificate.persentation.data;
+package team.incube.gsmc.v2.domain.certificate.presentation.data;
 
 
 /**

--- a/src/main/java/team/incube/gsmc/v2/domain/certificate/presentation/data/request/CreateCertificateRequest.java
+++ b/src/main/java/team/incube/gsmc/v2/domain/certificate/presentation/data/request/CreateCertificateRequest.java
@@ -1,4 +1,4 @@
-package team.incube.gsmc.v2.domain.certificate.persentation.data.request;
+package team.incube.gsmc.v2.domain.certificate.presentation.data.request;
 
 import jakarta.validation.constraints.NotNull;
 import org.springframework.web.multipart.MultipartFile;

--- a/src/main/java/team/incube/gsmc/v2/domain/certificate/presentation/data/request/PatchCertificateRequest.java
+++ b/src/main/java/team/incube/gsmc/v2/domain/certificate/presentation/data/request/PatchCertificateRequest.java
@@ -1,4 +1,4 @@
-package team.incube.gsmc.v2.domain.certificate.persentation.data.request;
+package team.incube.gsmc.v2.domain.certificate.presentation.data.request;
 
 import org.springframework.web.multipart.MultipartFile;
 

--- a/src/main/java/team/incube/gsmc/v2/domain/certificate/presentation/data/response/GetCertificateResponse.java
+++ b/src/main/java/team/incube/gsmc/v2/domain/certificate/presentation/data/response/GetCertificateResponse.java
@@ -1,6 +1,6 @@
-package team.incube.gsmc.v2.domain.certificate.persentation.data.response;
+package team.incube.gsmc.v2.domain.certificate.presentation.data.response;
 
-import team.incube.gsmc.v2.domain.certificate.persentation.data.GetCertificateDto;
+import team.incube.gsmc.v2.domain.certificate.presentation.data.GetCertificateDto;
 
 import java.util.List;
 

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -11,8 +11,8 @@ spring:
     database-platform: org.hibernate.dialect.MySQLDialect
   data:
     redis:
-      host: ${REDIS_HOST:localhost}
-      port: ${REDIS_PORT:6379}
+      host: localhost
+      port: 6379
   sql:
     init:
       mode: always

--- a/src/test/java/team/incube/gsmc/v2/domain/certificate/application/usecase/service/FindCertificateServiceTest.java
+++ b/src/test/java/team/incube/gsmc/v2/domain/certificate/application/usecase/service/FindCertificateServiceTest.java
@@ -9,7 +9,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import team.incube.gsmc.v2.domain.certificate.application.port.CertificatePersistencePort;
 import team.incube.gsmc.v2.domain.certificate.domain.Certificate;
-import team.incube.gsmc.v2.domain.certificate.persentation.data.response.GetCertificateResponse;
+import team.incube.gsmc.v2.domain.certificate.presentation.data.response.GetCertificateResponse;
 import team.incube.gsmc.v2.domain.evidence.domain.OtherEvidence;
 import team.incube.gsmc.v2.domain.member.application.port.StudentDetailPersistencePort;
 import team.incube.gsmc.v2.domain.member.domain.Member;


### PR DESCRIPTION
## 📋 작업 내용
> ``certificate`` 모델의 프레젠테이션 계층 패키지명이 ``preseantaion``이 아니라 ``persentation``으로 되있던 문제를 해결하였습니다

## 🤝 리뷰 시 참고사항
> 총 11개 파일을 건드리는 PR로 주의하여주세요

## ✅ 체크리스트
- [x] 이 작업으로 인해 변경이 필요한 문서를 작성 또는 수정했나요? (e.g. `README`, `.env.example`)
- [x] 작업한 코드가 정상적으로 동작하는지 확인했나요?
- [x] 작업한 코드에 대한 테스트 코드를 작성하거나 수정했나요?
- [x] Merge 대상 브랜치를 올바르게 설정했나요?
- [x] 해당 PR과 관련 없는 작업이 포함되지는 않았나요?
- [x] PR의 올바른 라벨과 리뷰어를 설정했나요?