### PR TITLE
비밀번호 필드 길이 최소 제한 추가

### DIFF
--- a/src/main/java/team/incube/gsmc/v2/domain/auth/presentation/data/request/ChangePasswordRequest.java
+++ b/src/main/java/team/incube/gsmc/v2/domain/auth/presentation/data/request/ChangePasswordRequest.java
@@ -9,13 +9,13 @@ import jakarta.validation.constraints.Size;
  * <p>사용자의 이메일과 새 비밀번호를 전달받아 비밀번호를 갱신합니다.
  * <ul>
  *   <li>{@code email} - 변경 대상 사용자의 이메일 주소 (유효성 검증 포함)</li>
- *   <li>{@code password} - 새 비밀번호 (8자 이상 20자 이하)</li>
+ *   <li>{@code password} - 새 비밀번호 (8자 이상 30자 이하)</li>
  * </ul>
  * 이 요청은 인증이 필요한 사용자가 자신의 비밀번호를 갱신할 때 사용됩니다.
  * @author jihoonwjj
  */
 public record ChangePasswordRequest(
-        @Email @NotBlank @Size(min=3, max=50) String email,
-        @NotBlank @Size(min=8, max=20) String password
+        @Email @NotBlank @Size(min=5, max=50) String email,
+        @NotBlank @Size(min=8, max=30) String password
 ) {
 }

--- a/src/main/java/team/incube/gsmc/v2/domain/auth/presentation/data/request/SignInRequest.java
+++ b/src/main/java/team/incube/gsmc/v2/domain/auth/presentation/data/request/SignInRequest.java
@@ -7,12 +7,12 @@ import jakarta.validation.constraints.Size;
 /**
  * 로그인 요청에 사용되는 DTO입니다.
  * <p>사용자가 입력한 이메일과 비밀번호를 기반으로 인증을 수행합니다.
- * @param email 로그인할 사용자 이메일 (이메일 형식, 최대 16자)
- * @param password 로그인할 사용자 비밀번호 (최대 30자)
+ * @param email    로그인할 사용자 이메일 (이메일 형식, 최소 5자/최대 50자)
+ * @param password 로그인할 사용자 비밀번호 (최소 8자/최대 30자)
  * @author jihoonwjj
  */
 public record SignInRequest(
-        @Email @NotBlank @Size(max=16) String email,
-        @NotBlank @Size(max=30) String password
+        @Email @NotBlank @Size(min = 5, max = 50) String email,
+        @NotBlank @Size(min = 8, max = 30) String password
 ) {
 }

--- a/src/main/java/team/incube/gsmc/v2/domain/auth/presentation/data/request/SignUpRequest.java
+++ b/src/main/java/team/incube/gsmc/v2/domain/auth/presentation/data/request/SignUpRequest.java
@@ -7,14 +7,14 @@ import jakarta.validation.constraints.Size;
 /**
  * 회원 가입 요청에 사용되는 DTO입니다.
  * <p>사용자의 이름, 이메일, 비밀번호를 입력받아 신규 회원을 등록합니다.
- * @param name 사용자 이름 (최대 20자)
- * @param email 사용자 이메일 (이메일 형식, 최대 50자)
- * @param password 사용자 비밀번호 (최대 30자)
+ * @param name     사용자 이름 (최대 20자)
+ * @param email    사용자 이메일 (이메일 형식, 최소 5자/최대 50자)
+ * @param password 사용자 비밀번호 (최소 8자/최대 30자)
  * @author jihoonwjj
  */
 public record SignUpRequest(
-        @NotBlank @Size(max=20) String name,
-        @Email @NotBlank @Size(min=5, max=50) String email,
-        @NotBlank @Size(max=30) String password
+        @NotBlank @Size(max = 20) String name,
+        @Email @NotBlank @Size(min = 5, max = 50) String email,
+        @NotBlank @Size(min = 8, max = 30) String password
 ) {
 }


### PR DESCRIPTION
## 📋 작업 내용
> #158 문제를 수정하기 위해서 기존 DTO에 걸려있던 검증 어노테이션의 파라미터를 수정하였습니다

## 🤝 리뷰 시 참고사항
> 클라이언트 기능명세서와 최대길이 제한이 다른데 해당 부분은 과거 서버 애플리케이션에서 일부러 여유있게 잡은것입니다.이에 대해서 다른 의견 있으시면 말씀해주세요

## ✅ 체크리스트
- [x] 이 작업으로 인해 변경이 필요한 문서를 작성 또는 수정했나요? (e.g. `README`, `.env.example`)
- [x] 작업한 코드가 정상적으로 동작하는지 확인했나요?
- [x] 작업한 코드에 대한 테스트 코드를 작성하거나 수정했나요?
- [x] Merge 대상 브랜치를 올바르게 설정했나요?
- [x] 해당 PR과 관련 없는 작업이 포함되지는 않았나요?
- [x] PR의 올바른 라벨과 리뷰어를 설정했나요?