### PR TITLE
JavaDoc 누락 클래스/인터페이스 주석 추가

### DIFF
--- a/src/main/java/team/incube/gsmc/v2/GsmcApplication.java
+++ b/src/main/java/team/incube/gsmc/v2/GsmcApplication.java
@@ -3,6 +3,13 @@ package team.incube.gsmc.v2;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
+/**
+ * GSMC 애플리케이션의 진입점입니다.
+ * <p>이 클래스는 Spring Boot 애플리케이션을 시작하며, 필요한 모든 설정과 컴포넌트를 자동으로 구성합니다.
+ * <p>애플리케이션은 기본적으로 `src/main/resources/application.yml` 파일에서 설정을 읽어들입니다.
+ * <p>애플리케이션을 실행하려면 `main` 메서드를 호출하면 됩니다.
+ * @author suuuuuuminnnnnn
+ */
 @SpringBootApplication
 public class GsmcApplication {
 

--- a/src/main/java/team/incube/gsmc/v2/global/config/PropertiesScanConfig.java
+++ b/src/main/java/team/incube/gsmc/v2/global/config/PropertiesScanConfig.java
@@ -5,6 +5,13 @@ import org.springframework.context.annotation.Configuration;
 import team.incube.gsmc.v2.global.security.jwt.data.JwtEnvironment;
 import team.incube.gsmc.v2.global.thirdparty.aws.data.AwsEnvironment;
 
+/**
+ * 애플리케이션 전역에서 사용할 프로퍼티 설정 클래스입니다.
+ * <p>{@link EnableConfigurationProperties}를 통해 {@link AwsEnvironment}와 {@link JwtEnvironment} 클래스를
+ * 프로퍼티 소스로 등록하여, 외부 설정 파일(application.yml 등)에서 주입받은 값을 사용할 수 있도록 합니다.
+ * 이 설정은 AWS 관련 설정과 JWT 관련 설정을 관리하는 데 사용됩니다.
+ * @author jihoonwjj
+ */
 @EnableConfigurationProperties({AwsEnvironment.class, JwtEnvironment.class})
 @Configuration
 public class PropertiesScanConfig {

--- a/src/main/java/team/incube/gsmc/v2/global/config/RetryConfig.java
+++ b/src/main/java/team/incube/gsmc/v2/global/config/RetryConfig.java
@@ -6,6 +6,13 @@ import org.springframework.retry.support.RetryTemplate;
 
 import java.io.IOException;
 
+/**
+ * 애플리케이션 전역에서 사용할 Retry 설정 클래스입니다.
+ * <p>Spring Retry를 사용하여 특정 예외 발생 시 재시도 로직을 구성합니다.
+ * <p>{@link RetryTemplate}을 빈으로 등록하여, 최대 3번의 재시도와 1초의 고정 백오프를 설정합니다.
+ * 이 설정은 주로 외부 API 호출이나 데이터베이스 작업 등에서 일시적인 오류를 처리하기 위해 사용됩니다.
+ * @author suuuuuuminnnnnn
+ */
 @Configuration
 public class RetryConfig {
 

--- a/src/main/java/team/incube/gsmc/v2/global/security/jwt/data/JwtEnvironment.java
+++ b/src/main/java/team/incube/gsmc/v2/global/security/jwt/data/JwtEnvironment.java
@@ -2,6 +2,14 @@ package team.incube.gsmc.v2.global.security.jwt.data;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
+/**
+ * JWT 환경 설정을 위한 데이터 클래스입니다.
+ * <p>이 클래스는 액세스 토큰과 리프레시 토큰에 대한 설정을 포함하며, Spring Boot의 {@link ConfigurationProperties}를 사용하여
+ * application.yml 또는 application.properties 파일에서 설정 값을 자동으로 매핑합니다.
+ * <p>주요 필드로는 액세스 토큰과 리프레시 토큰의 비밀 키와 만료 시간을 포함합니다.
+ * 이 설정을 통해 JWT 인증 및 인가를 위한 토큰 관리가 가능합니다.
+ * @author jihoonwjj
+ */
 @ConfigurationProperties(prefix="jwt")
 public record JwtEnvironment(
 

--- a/src/main/java/team/incube/gsmc/v2/global/security/jwt/data/TokenDto.java
+++ b/src/main/java/team/incube/gsmc/v2/global/security/jwt/data/TokenDto.java
@@ -2,5 +2,12 @@ package team.incube.gsmc.v2.global.security.jwt.data;
 
 import java.time.LocalDateTime;
 
+/**
+ * JWT 토큰 정보를 나타내는 데이터 전송 객체(DTO)입니다.
+ * <p>이 클래스는 JWT 토큰과 해당 토큰의 만료 시간을 포함하며, 클라이언트와 서버 간의 데이터 전송에 사용됩니다.
+ * @param token JWT 토큰 문자열
+ * @param expiration 토큰의 만료 시간
+ * @author jihoonwjj
+ */
 public record TokenDto(String token, LocalDateTime expiration) {
 }

--- a/src/main/java/team/incube/gsmc/v2/global/security/jwt/persistence/entity/RefreshTokenRedisEntity.java
+++ b/src/main/java/team/incube/gsmc/v2/global/security/jwt/persistence/entity/RefreshTokenRedisEntity.java
@@ -10,6 +10,13 @@ import org.springframework.data.redis.core.index.Indexed;
 
 import java.util.concurrent.TimeUnit;
 
+/**
+ * Redis에 저장되는 Refresh Token 엔티티 클래스입니다.
+ * <p>이 클래스는 Redis에 저장될 Refresh Token의 구조를 정의하며, 토큰, 이메일, 만료 시간을 포함합니다.
+ * <p>토큰은 고유 식별자로 사용되며, 이메일은 해당 토큰과 연관된 사용자 식별을 위해 사용됩니다.
+ * 만료 시간은 토큰의 유효 기간을 나타내며, Redis에서 자동으로 삭제되도록 설정됩니다.
+ * @author jihoonwjj
+ */
 @RedisHash("refresh_token")
 @Getter
 @NoArgsConstructor

--- a/src/main/java/team/incube/gsmc/v2/global/security/jwt/persistence/repository/RefreshTokenRedisRepository.java
+++ b/src/main/java/team/incube/gsmc/v2/global/security/jwt/persistence/repository/RefreshTokenRedisRepository.java
@@ -4,6 +4,13 @@ import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
 import team.incube.gsmc.v2.global.security.jwt.persistence.entity.RefreshTokenRedisEntity;
 
+/**
+ * Redis에 저장되는 Refresh Token 엔티티를 관리하는 리포지토리 인터페이스입니다.
+ * <p>이 인터페이스는 Spring Data Redis의 CrudRepository를 확장하여, Refresh Token 엔티티에 대한 CRUD
+ * (생성, 읽기, 업데이트, 삭제) 작업을 지원합니다. Redis에 저장된 Refresh Token을 효율적으로 관리할 수 있도록
+ * 설계되었습니다.
+ * @author jihoonwjj
+ */
 @Repository
 public interface RefreshTokenRedisRepository extends CrudRepository<RefreshTokenRedisEntity, String> {
 }

--- a/src/main/java/team/incube/gsmc/v2/global/thirdparty/aws/data/AwsEnvironment.java
+++ b/src/main/java/team/incube/gsmc/v2/global/thirdparty/aws/data/AwsEnvironment.java
@@ -2,6 +2,18 @@ package team.incube.gsmc.v2.global.thirdparty.aws.data;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
+/**
+ * AWS 환경 설정을 위한 데이터 클래스입니다.
+ * <p>이 클래스는 AWS S3 버킷과 관련된 설정을 포함하며, Spring Boot의 {@link ConfigurationProperties}를 사용하여
+ * application.yml 또는 application.properties 파일에서
+ * 설정 값을 자동으로 매핑합니다.
+ * <p>주요 필드로는 AWS 액세스 키 ID, 비밀 액세스 키, 그리고 S3 버킷의 이름과 지역이 있습니다.
+ * * 이 설정을 통해 AWS S3와의 통신을 위한 인증 정보와 버킷 정보를 관리할 수 있습니다.
+ * @author jihoonwjj
+ * @param accessKeyId
+ * @param secretAccessKey
+ * @param bucket
+ */
 @ConfigurationProperties(prefix="aws")
 public record AwsEnvironment(
 


### PR DESCRIPTION
## 📋 작업 내용
> JWT와 설정 클래스 일부에서 JavaDoc 주석이 누락되어 있는 부분을 추가하였습니다

## 🤝 리뷰 시 참고사항
> ``GsmcApplication`` 클래스에도 일단 주석을 추가했는데 사실 기본 클래스여서 의미가 있나 생각이 듭니다.어떠신가요?

## ✅ 체크리스트
- [x] 이 작업으로 인해 변경이 필요한 문서를 작성 또는 수정했나요? (e.g. `README`, `.env.example`)
- [x] 작업한 코드가 정상적으로 동작하는지 확인했나요?
- [x] 작업한 코드에 대한 테스트 코드를 작성하거나 수정했나요?
- [x] Merge 대상 브랜치를 올바르게 설정했나요?
- [x] 해당 PR과 관련 없는 작업이 포함되지는 않았나요?
- [x] PR의 올바른 라벨과 리뷰어를 설정했나요?
## ℹ️ RCA Rule
> PR 리뷰 시 아래의 규칙을 참고해주세요.
```
R (Request Changes) : 적극적으로 반영을 고려해주세요.
C (Comment) : 웬만하면 반영해주세요.
A (Approve) : 반영해도 좋고, 넘어가도 좋습니다. 사소한 의견입니다.
```