### PR TITLE
학생 검색 API에 정렬 기능 추가

### DIFF
--- a/src/main/java/team/incube/gsmc/v2/domain/member/application/MemberApplicationAdapter.java
+++ b/src/main/java/team/incube/gsmc/v2/domain/member/application/MemberApplicationAdapter.java
@@ -6,6 +6,7 @@ import team.incube.gsmc.v2.domain.member.application.usecase.FindAllStudentUseCa
 import team.incube.gsmc.v2.domain.member.application.usecase.FindCurrentStudentUseCase;
 import team.incube.gsmc.v2.domain.member.application.usecase.FindStudentByEmailUseCase;
 import team.incube.gsmc.v2.domain.member.application.usecase.SearchStudentUseCase;
+import team.incube.gsmc.v2.domain.member.domain.constant.MemberSortDirection;
 import team.incube.gsmc.v2.domain.member.presentation.data.response.GetStudentResponse;
 import team.incube.gsmc.v2.domain.member.presentation.data.response.SearchStudentResponse;
 import team.incube.gsmc.v2.global.annotation.PortDirection;
@@ -41,8 +42,8 @@ public class MemberApplicationAdapter implements MemberApplicationPort {
     }
 
     @Override
-    public SearchStudentResponse searchStudents(String name, Integer grade, Integer classNumber, Integer page, Integer size) {
-        return searchStudentUseCase.execute(name, grade, classNumber, page, size);
+    public SearchStudentResponse searchStudents(String name, Integer grade, Integer classNumber, MemberSortDirection sortBy, Integer page, Integer size) {
+        return searchStudentUseCase.execute(name, grade, classNumber, sortBy, page, size);
     }
 
     @Override

--- a/src/main/java/team/incube/gsmc/v2/domain/member/application/port/MemberApplicationPort.java
+++ b/src/main/java/team/incube/gsmc/v2/domain/member/application/port/MemberApplicationPort.java
@@ -1,5 +1,6 @@
 package team.incube.gsmc.v2.domain.member.application.port;
 
+import team.incube.gsmc.v2.domain.member.domain.constant.MemberSortDirection;
 import team.incube.gsmc.v2.domain.member.presentation.data.response.GetStudentResponse;
 import team.incube.gsmc.v2.domain.member.presentation.data.response.SearchStudentResponse;
 import team.incube.gsmc.v2.global.annotation.PortDirection;
@@ -24,7 +25,7 @@ import java.util.List;
 public interface MemberApplicationPort {
     List<GetStudentResponse> findAllStudents();
 
-    SearchStudentResponse searchStudents(String name, Integer grade, Integer classNumber, Integer page, Integer size);
+    SearchStudentResponse searchStudents(String name, Integer grade, Integer classNumber, MemberSortDirection sortBy, Integer page, Integer size);
 
     GetStudentResponse findCurrentStudent();
 

--- a/src/main/java/team/incube/gsmc/v2/domain/member/application/port/StudentDetailPersistencePort.java
+++ b/src/main/java/team/incube/gsmc/v2/domain/member/application/port/StudentDetailPersistencePort.java
@@ -4,8 +4,10 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import team.incube.gsmc.v2.domain.member.domain.StudentDetail;
 import team.incube.gsmc.v2.domain.member.domain.StudentDetailWithEvidence;
+import team.incube.gsmc.v2.domain.member.domain.constant.MemberSortDirection;
 import team.incube.gsmc.v2.global.annotation.PortDirection;
 import team.incube.gsmc.v2.global.annotation.port.Port;
+import com.querydsl.core.types.OrderSpecifier;
 
 import java.util.List;
 
@@ -29,10 +31,6 @@ import java.util.List;
 @Port(direction = PortDirection.OUTBOUND)
 public interface StudentDetailPersistencePort {
     StudentDetail findStudentDetailByEmail(String email);
-
-    StudentDetail findStudentDetailByEmailWithLock(String email);
-    
-    StudentDetail findStudentDetailByStudentCode(String studentCode);
     
     StudentDetail findStudentDetailByStudentCodeWithLock(String studentCode);
 
@@ -40,13 +38,11 @@ public interface StudentDetailPersistencePort {
 
     List<StudentDetail> findStudentDetailByGradeAndClassNumberAndMemberNotNull(Integer grade, Integer classNumber);
 
-    StudentDetailWithEvidence findStudentDetailWithEvidenceByEmail(String email);
-
     StudentDetailWithEvidence findStudentDetailWithEvidenceByMemberEmail(String email);
 
     List<StudentDetailWithEvidence> findStudentDetailWithEvidenceReviewStatusNotNullMember();
 
-    Page<StudentDetailWithEvidence> searchStudentDetailWithEvidenceReviewStatusNotNullMember(String name, Integer grade, Integer classNumber, Pageable pageable);
+    Page<StudentDetailWithEvidence> searchStudentDetailWithEvidenceReviewStatusNotNullMember(String name, Integer grade, Integer classNumber, MemberSortDirection sortBy, Pageable pageable);
 
     Integer findTotalScoreByEmail(String email);
 

--- a/src/main/java/team/incube/gsmc/v2/domain/member/application/usecase/SearchStudentUseCase.java
+++ b/src/main/java/team/incube/gsmc/v2/domain/member/application/usecase/SearchStudentUseCase.java
@@ -1,5 +1,6 @@
 package team.incube.gsmc.v2.domain.member.application.usecase;
 
+import team.incube.gsmc.v2.domain.member.domain.constant.MemberSortDirection;
 import team.incube.gsmc.v2.domain.member.presentation.data.response.SearchStudentResponse;
 
 /**
@@ -9,5 +10,5 @@ import team.incube.gsmc.v2.domain.member.presentation.data.response.SearchStuden
  * @author snowykte0426
  */
 public interface SearchStudentUseCase {
-    SearchStudentResponse execute(String name, Integer grade, Integer classNumber, Integer page, Integer size);
+    SearchStudentResponse execute(String name, Integer grade, Integer classNumber, MemberSortDirection sortBy, Integer page, Integer size);
 }

--- a/src/main/java/team/incube/gsmc/v2/domain/member/application/usecase/service/SearchStudentService.java
+++ b/src/main/java/team/incube/gsmc/v2/domain/member/application/usecase/service/SearchStudentService.java
@@ -2,11 +2,13 @@ package team.incube.gsmc.v2.domain.member.application.usecase.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import team.incube.gsmc.v2.domain.member.application.port.StudentDetailPersistencePort;
 import team.incube.gsmc.v2.domain.member.application.usecase.SearchStudentUseCase;
 import team.incube.gsmc.v2.domain.member.domain.StudentDetailWithEvidence;
+import team.incube.gsmc.v2.domain.member.domain.constant.MemberSortDirection;
 import team.incube.gsmc.v2.domain.member.presentation.data.response.GetStudentResponse;
 import team.incube.gsmc.v2.domain.member.presentation.data.response.SearchStudentResponse;
 
@@ -15,6 +17,7 @@ import team.incube.gsmc.v2.domain.member.presentation.data.response.SearchStuden
  * <p>{@link SearchStudentUseCase}를 구현하며, 이름, 학년, 반 번호를 기준으로 필터링된 학생 목록을 페이징 처리하여 조회합니다.
  * <p>{@link StudentDetailPersistencePort}를 통해 영속성 계층에서 검색 쿼리를 수행하고,
  * 결과는 {@link SearchStudentResponse}로 매핑되어 클라이언트에 전달됩니다.
+ * <p>선택적으로 결과를 정렬할 수 있습니다.
  * <p>검색 결과에는 학생의 점수, 증빙자료 상태, 권한 정보 등이 포함됩니다.
  * @author snowykte0426
  */
@@ -25,8 +28,12 @@ public class SearchStudentService implements SearchStudentUseCase {
     private final StudentDetailPersistencePort studentDetailPersistencePort;
 
     @Override
-    public SearchStudentResponse execute(String name, Integer grade, Integer classNumber, Integer page, Integer size) {
-        Page<StudentDetailWithEvidence> studentDetails = studentDetailPersistencePort.searchStudentDetailWithEvidenceReviewStatusNotNullMember(name, grade, classNumber, Pageable.ofSize(size));
+    public SearchStudentResponse execute(String name, Integer grade, Integer classNumber, MemberSortDirection sortBy, Integer page, Integer size) {
+        Pageable pageable = PageRequest.of(page, size);
+        
+        Page<StudentDetailWithEvidence> studentDetails = studentDetailPersistencePort
+                .searchStudentDetailWithEvidenceReviewStatusNotNullMember(name, grade, classNumber, sortBy, pageable);
+        
         return new SearchStudentResponse(
                 studentDetails.getTotalPages(),
                 studentDetails.getTotalElements(),

--- a/src/main/java/team/incube/gsmc/v2/domain/member/domain/constant/MemberSortDirection.java
+++ b/src/main/java/team/incube/gsmc/v2/domain/member/domain/constant/MemberSortDirection.java
@@ -1,21 +1,57 @@
 package team.incube.gsmc.v2.domain.member.domain.constant;
 
+import com.querydsl.core.types.OrderSpecifier;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import static team.incube.gsmc.v2.domain.member.persistence.entity.QStudentDetailJpaEntity.studentDetailJpaEntity;
+
 /**
  * 회원 정렬 방향을 정의하는 열거형입니다.
  * <p>회원 목록을 다양한 기준으로 정렬할 때 사용됩니다.
- * 각 상수는 정렬 기준과 방향을 나타냅니다.
+ * 각 상수는 정렬 기준과 방향을 나타내며, 정렬 필드와 방향 정보를 포함합니다.
  * @author snowykte0426
  */
+@Getter
+@RequiredArgsConstructor
 public enum MemberSortDirection {
-    TOTAL_SCORE_ASC,
-    TOTAL_SCORE_DESC,
+    TOTAL_SCORE_ASC("totalScore", "asc"),
+    TOTAL_SCORE_DESC("totalScore", "desc"),
 
-    NAME_ASC,
-    NAME_DESC,
+    NAME_ASC("name", "asc"),
+    NAME_DESC("name", "desc"),
 
-    GRADE_AND_CLASS_ASC,
-    GRADE_AND_CLASS_DESC,
+    GRADE_AND_CLASS_ASC("gradeAndClass", "asc"),
+    GRADE_AND_CLASS_DESC("gradeAndClass", "desc"),
 
-    STUDENT_CODE_ASC,
-    STUDENT_CODE_DESC,
+    STUDENT_CODE_ASC("studentCode", "asc"),
+    STUDENT_CODE_DESC("studentCode", "desc");
+
+    private final String field;
+    private final String direction;
+
+    /**
+     * 정렬 방향에 따른 QueryDSL OrderSpecifier를 반환합니다.
+     * @return QueryDSL OrderSpecifier 배열
+     */
+    public OrderSpecifier<?>[] getOrderSpecifiers() {
+        return switch (this) {
+            case TOTAL_SCORE_ASC -> new OrderSpecifier[]{studentDetailJpaEntity.totalScore.max().asc()};
+            case TOTAL_SCORE_DESC -> new OrderSpecifier[]{studentDetailJpaEntity.totalScore.max().desc()};
+            case NAME_ASC -> new OrderSpecifier[]{studentDetailJpaEntity.member.name.min().asc()};
+            case NAME_DESC -> new OrderSpecifier[]{studentDetailJpaEntity.member.name.min().desc()};
+            case GRADE_AND_CLASS_ASC -> new OrderSpecifier[]{
+                studentDetailJpaEntity.grade.min().asc(),
+                studentDetailJpaEntity.classNumber.min().asc(),
+                studentDetailJpaEntity.number.min().asc()
+            };
+            case GRADE_AND_CLASS_DESC -> new OrderSpecifier[]{
+                studentDetailJpaEntity.grade.min().desc(),
+                studentDetailJpaEntity.classNumber.min().desc(),
+                studentDetailJpaEntity.number.min().desc()
+            };
+            case STUDENT_CODE_ASC -> new OrderSpecifier[]{studentDetailJpaEntity.studentCode.min().asc()};
+            case STUDENT_CODE_DESC -> new OrderSpecifier[]{studentDetailJpaEntity.studentCode.min().desc()};
+        };
+    }
 }

--- a/src/main/java/team/incube/gsmc/v2/domain/member/domain/constant/MemberSortDirection.java
+++ b/src/main/java/team/incube/gsmc/v2/domain/member/domain/constant/MemberSortDirection.java
@@ -1,0 +1,21 @@
+package team.incube.gsmc.v2.domain.member.domain.constant;
+
+/**
+ * 회원 정렬 방향을 정의하는 열거형입니다.
+ * <p>회원 목록을 다양한 기준으로 정렬할 때 사용됩니다.
+ * 각 상수는 정렬 기준과 방향을 나타냅니다.
+ * @author snowykte0426
+ */
+public enum MemberSortDirection {
+    TOTAL_SCORE_ASC,
+    TOTAL_SCORE_DESC,
+
+    NAME_ASC,
+    NAME_DESC,
+
+    GRADE_AND_CLASS_ASC,
+    GRADE_AND_CLASS_DESC,
+
+    STUDENT_CODE_ASC,
+    STUDENT_CODE_DESC,
+}

--- a/src/main/java/team/incube/gsmc/v2/domain/member/domain/constant/MemberSortDirection.java
+++ b/src/main/java/team/incube/gsmc/v2/domain/member/domain/constant/MemberSortDirection.java
@@ -29,29 +29,4 @@ public enum MemberSortDirection {
 
     private final String field;
     private final String direction;
-
-    /**
-     * 정렬 방향에 따른 QueryDSL OrderSpecifier를 반환합니다.
-     * @return QueryDSL OrderSpecifier 배열
-     */
-    public OrderSpecifier<?>[] getOrderSpecifiers() {
-        return switch (this) {
-            case TOTAL_SCORE_ASC -> new OrderSpecifier[]{studentDetailJpaEntity.totalScore.max().asc()};
-            case TOTAL_SCORE_DESC -> new OrderSpecifier[]{studentDetailJpaEntity.totalScore.max().desc()};
-            case NAME_ASC -> new OrderSpecifier[]{studentDetailJpaEntity.member.name.min().asc()};
-            case NAME_DESC -> new OrderSpecifier[]{studentDetailJpaEntity.member.name.min().desc()};
-            case GRADE_AND_CLASS_ASC -> new OrderSpecifier[]{
-                studentDetailJpaEntity.grade.min().asc(),
-                studentDetailJpaEntity.classNumber.min().asc(),
-                studentDetailJpaEntity.number.min().asc()
-            };
-            case GRADE_AND_CLASS_DESC -> new OrderSpecifier[]{
-                studentDetailJpaEntity.grade.min().desc(),
-                studentDetailJpaEntity.classNumber.min().desc(),
-                studentDetailJpaEntity.number.min().desc()
-            };
-            case STUDENT_CODE_ASC -> new OrderSpecifier[]{studentDetailJpaEntity.studentCode.min().asc()};
-            case STUDENT_CODE_DESC -> new OrderSpecifier[]{studentDetailJpaEntity.studentCode.min().desc()};
-        };
-    }
 }

--- a/src/main/java/team/incube/gsmc/v2/domain/member/presentation/MemberWebAdapter.java
+++ b/src/main/java/team/incube/gsmc/v2/domain/member/presentation/MemberWebAdapter.java
@@ -8,6 +8,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import team.incube.gsmc.v2.domain.member.application.port.MemberApplicationPort;
+import team.incube.gsmc.v2.domain.member.domain.constant.MemberSortDirection;
 import team.incube.gsmc.v2.domain.member.presentation.data.response.GetStudentResponse;
 import team.incube.gsmc.v2.domain.member.presentation.data.response.SearchStudentResponse;
 
@@ -44,6 +45,7 @@ public class MemberWebAdapter {
             @RequestParam(value = "grade", required = false) Integer grade,
             @RequestParam(value = "classNumber", required = false) Integer classNumber,
             @RequestParam(value = "name", required = false) String name,
+            @RequestParam(value = "sortBy", required = false) MemberSortDirection sortBy,
             @RequestParam(value = "page", defaultValue = "0") @Min(value = 0) Integer page,
             @RequestParam(value = "size", defaultValue = "10") @Positive Integer size
     ) {

--- a/src/main/java/team/incube/gsmc/v2/domain/member/presentation/MemberWebAdapter.java
+++ b/src/main/java/team/incube/gsmc/v2/domain/member/presentation/MemberWebAdapter.java
@@ -49,7 +49,7 @@ public class MemberWebAdapter {
             @RequestParam(value = "page", defaultValue = "0") @Min(value = 0) Integer page,
             @RequestParam(value = "size", defaultValue = "10") @Positive Integer size
     ) {
-        return ResponseEntity.status(HttpStatus.OK).body(memberApplicationPort.searchStudents(name, grade, classNumber, page, size));
+        return ResponseEntity.status(HttpStatus.OK).body(memberApplicationPort.searchStudents(name, grade, classNumber, sortBy, page, size));
     }
 
     @GetMapping("/students/current")


### PR DESCRIPTION
## 📋 작업 내용
> ``GET /api/v2/members/students/search`` API에 ``sortBy`` 쿼리 파라미터를 추가하여 데이터의 정렬을 제어할 수 있도록 개선하였습니다

```
TOTAL_SCORE_ASC
TOTAL_SCORE_DESC
NAME_ASC
NAME_DESC
GRADE_AND_CLASS_ASC
GRADE_AND_CLASS_DESC
STUDENT_CODE_ASC
STUDENT_CODE_DESC
```
다음 파라미터들을 이용할 수 있습니다.
또한, 기존에는 무조건 ``studentCode`` 필드를 이용하여 오름차순 정렬하였으나 기능 추가에 따라 정렬 파라미터가 값이 없다면 무순서로 반환됩니다
## 🤝 리뷰 시 참고사항
> Enum 클래스에서 QueryDSL 관련 메서드를 의존하도록 되었는데 알맞은 설계인지 모르겠습니다.그리고 ``StudentDetailPersistenceAdapter``에서도 본래 검색 메서드는 다른 메서드와 다르게 예외적으로 페이징 처리를 위한 로직이 포함되었지만 정렬 기능 추가로 더 책임을 추가적으로 지게 되어 더 나은 방안이 있다면 알려주시면 좋겠습니다.
## ✅ 체크리스트
- [x] 이 작업으로 인해 변경이 필요한 문서를 작성 또는 수정했나요? (e.g. `README`, `.env.example`)
- [x] 작업한 코드가 정상적으로 동작하는지 확인했나요?
- [x] 작업한 코드에 대한 테스트 코드를 작성하거나 수정했나요?
- [x] Merge 대상 브랜치를 올바르게 설정했나요?
- [x] 해당 PR과 관련 없는 작업이 포함되지는 않았나요?
- [x] PR의 올바른 라벨과 리뷰어를 설정했나요?
## ℹ️ RCA Rule
> PR 리뷰 시 아래의 규칙을 참고해주세요.
```
R (Request Changes) : 적극적으로 반영을 고려해주세요.
C (Comment) : 웬만하면 반영해주세요.
A (Approve) : 반영해도 좋고, 넘어가도 좋습니다. 사소한 의견입니다.
```